### PR TITLE
Add Scenario Selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/sftp.json

--- a/eminentdomain.action.php
+++ b/eminentdomain.action.php
@@ -3,7 +3,7 @@
 /**
  *------
  * BGA framework: © Gregory Isabelli <gisabelli@boardgamearena.com> & Emmanuel Colin <ecolin@boardgamearena.com>
- * EminentDomain implementation : © Alena Laskavaia <laskava@gmail.com>
+ * eminentdomain implementation : © Alena Laskavaia <laskava@gmail.com>
  *
  * This code has been produced on the BGA studio platform for use on http://boardgamearena.com.
  * See http://en.boardgamearena.com/#!doc/Studio for more information.
@@ -104,6 +104,13 @@ class action_eminentdomain extends APP_GameAction {
     public function playWait() {
         self::setAjaxMode();
         $this->game->action_playWait();
+        self::ajaxResponse();
+    }
+
+    public function selectScenario(){
+        self::setAjaxMode();
+        $card = self::getArg("card", AT_alphanum, true);
+        $this->game->action_selectScenario($card);
         self::ajaxResponse();
     }
 

--- a/eminentdomain.action.php
+++ b/eminentdomain.action.php
@@ -3,7 +3,7 @@
 /**
  *------
  * BGA framework: © Gregory Isabelli <gisabelli@boardgamearena.com> & Emmanuel Colin <ecolin@boardgamearena.com>
- * eminentdomain implementation : © Alena Laskavaia <laskava@gmail.com>
+ * EminentDomain implementation : © Alena Laskavaia <laskava@gmail.com>
  *
  * This code has been produced on the BGA studio platform for use on http://boardgamearena.com.
  * See http://en.boardgamearena.com/#!doc/Studio for more information.

--- a/eminentdomain.css
+++ b/eminentdomain.css
@@ -441,6 +441,9 @@ html {
 .slot_board_r, .slot_board_5 {
 	left: 846px;
 }
+.slot_board_6 {
+	left: 1012px;
+}
 
 .slot_board > * {
 	position: absolute;
@@ -1876,7 +1879,6 @@ color: #773300;
 .scenario {
 	background-image: url(img/scenariosAll.jpg);
 	background-size: calc(400px * 6) calc(560px * 6);
-
 }
 
 .thething .scenario {
@@ -1989,6 +1991,14 @@ color: #773300;
 	display: none;
 }
 
+.clickable {
+	cursor: pointer;
+}
+
+.hidden {
+	display: none !important;
+}
+
 .slider {
 	height: 32px;
 	vertical-align: middle;
@@ -2016,6 +2026,11 @@ color: #773300;
 
 #selection_area .card {
   transition: opacity .2s;
+}
+#selection_area .scenario {
+	width: calc(400px * 0.5);
+	height: calc(560px * 0.5);
+	background-size: calc(400px * 6 * 0.5) calc(560px * 6 * 0.5); 
 }
 
 #selection_area_controls {

--- a/eminentdomain.game.php
+++ b/eminentdomain.game.php
@@ -15,15 +15,19 @@
  * In this PHP file, you are going to defines the rules of the game.
  *
  */
-require_once (APP_GAMEMODULE_PATH . 'module/table/table.game.php');
-require_once ('modules/EuroGame.php');
+
+use EminentDomain\Setup;
+
+require_once(APP_GAMEMODULE_PATH . 'module/table/table.game.php');
+require_once('modules/EuroGame.php');
+require_once('modules/php/EminentDomain/index.php');
 define("CARD_STATE_PERMANENT_TAPPED", 0);
 define("CARD_STATE_PERMANENT", 1);
 
 define("CARD_STATE_PARTIAL_ACTION", 11);
 define("CARD_STATE_TURN_LASTING", 10);
 define("CARD_STATE_USED_CARD", 12);
-define("CARD_STATE_PLANET_USED_AS_REQ",13);
+define("CARD_STATE_PLANET_USED_AS_REQ", 13);
 define("RESOURCE_STATE_COLONIZE_BOOST", 14);
 define("RESOURCE_STATE_BLOCKER", 1);
 define("RESOURCE_STATE_PRODUCE", 2);
@@ -40,9 +44,11 @@ define("CARD_RULE_ROLE", 300);
 define("CARD_RULE_ROLE_LEADER", 310);
 define("CARD_RULE_SPECIAL", 400);
 
-class EminentDomain extends EuroGame {
+class eminentdomain extends EuroGame
+{
 
-    function __construct() {
+    function __construct()
+    {
         // Your global variables labels:
         //  Here, you can assign labels to global variables you are using for this game.
         //  You can use any number of global variables with IDs between 10 and 99.
@@ -50,47 +56,61 @@ class EminentDomain extends EuroGame {
         //  the corresponding ID in gameoptions.inc.php.
         // Note: afterwards, you can get/set the global variables with getGameStateValue/setGameStateInitialValue/setGameStateValue
         parent::__construct();
-        self::initGameStateLabels(array (
-                // game global vars starts at 10
-                "action_played" => 11, // set to 1 if activate player played an action
-                "leader" => 12, // set to the leader id
-                "followers" => 13, // mask of which of players executed follow/descent
-                "followers_waiting" => 14, // mask of which of players are waiting
-                "active_follower" => 15, // follower who must follow/descent
-                "role" => 20, // current role number (index of role_icons array in material), -1 if not played
-                "end_of_game" => 21, // end of game has been triggered
-                "progression" => 22, // progression
-                "logistics_at_end" => 23, // logistics extra turn played
-                "extra_turn_at_end" => 24, //
-                "boost_rem" => 26, // how much of boost remains after role (used specific cards such as Scientific Method)
-                "actions_allowed" => 27, //
-                "role_phases_allowed" => 28, //
-                "role_phases_played" => 29, //
-                "discard_played" => 30, //
-                "follow_played" => 31, //
-                // variants
-                "learning_variant" => 100, //
-                "extended_variant" => 101, //
-                "scenarios_variant" => 102, //
-                "extra_turn_variant" => 103, //
-                "escalation_variant" => 104, // 
+        self::initGameStateLabels(array(
+            // game global vars starts at 10
+            "action_played" => 11, // set to 1 if activate player played an action
+            "leader" => 12, // set to the leader id
+            "followers" => 13, // mask of which of players executed follow/descent
+            "followers_waiting" => 14, // mask of which of players are waiting
+            "active_follower" => 15, // follower who must follow/descent
+            "role" => 20, // current role number (index of role_icons array in material), -1 if not played
+            "end_of_game" => 21, // end of game has been triggered
+            "progression" => 22, // progression
+            "logistics_at_end" => 23, // logistics extra turn played
+            "extra_turn_at_end" => 24, //
+            "boost_rem" => 26, // how much of boost remains after role (used specific cards such as Scientific Method)
+            "actions_allowed" => 27, //
+            "role_phases_allowed" => 28, //
+            "role_phases_played" => 29, //
+            "discard_played" => 30, //
+            "follow_played" => 31, //
+            "scenarios" => 32, //
+            // variants
+            "learning_variant" => 100, //
+            "extended_variant" => 101, //
+            "scenarios_variant" => 102, //
+            "extra_turn_variant" => 103, //
+            "escalation_variant" => 104, // 
+            "scenario_selection" => 105, // 
         ));
-        $this->tokens->autoreshuffle_custom = array ('supply_planets' => 'discard_planets' );
+        $this->tokens->autoreshuffle_custom = array('supply_planets' => 'discard_planets');
         $this->tokens->autoreshuffle = true;
         $gameinfos = self::getGameinfos();
-        $default_colors = $gameinfos ['player_colors'];
-        foreach ( $default_colors as $color ) {
-            $this->tokens->autoreshuffle_custom ["deck_$color"] = "discard_$color";
+        $default_colors = $gameinfos['player_colors'];
+        foreach ($default_colors as $color) {
+            $this->tokens->autoreshuffle_custom["deck_$color"] = "discard_$color";
         }
     }
 
-    protected function getGameName() {
+    protected function getGameName()
+    {
         // Used for translations and stuff. Please do not modify.
         return "eminentdomain";
     }
 
-    function isEscalationVariant() {
+    function isEscalationVariant()
+    {
         return $this->getGameStateValue('escalation_variant') == 2;
+    }
+
+    function isScenarioVariant()
+    {
+        return $this->getGameStateValue('scenarios_variant') == 2;
+    }
+
+    function isScenarioSelection()
+    {
+        return $this->getGameStateValue('scenario_selection') == 2;
     }
 
     /*
@@ -100,7 +120,8 @@ class EminentDomain extends EuroGame {
      * In this method, you must setup the game according to the game rules, so that
      * the game is ready to be played.
      */
-    protected function setupNewGame($players, $options = array ()) {
+    protected function setupNewGame($players, $options = array())
+    {
         /**
          * ********** Start the game initialization ****
          */
@@ -113,19 +134,15 @@ class EminentDomain extends EuroGame {
             $this->setGameStateValue('end_of_game', 0);
             $this->setGameStateValue('logistics_at_end', 0);
             $this->setGameStateValue('extra_turn_at_end', 0);
-            // begging of the turn for active player
-            $player_id = $this->getActivePlayerId();
-            $this->saction_TurnReplenish($player_id);
-            $this->incStat(1, 'turns_number', $player_id);
-            $this->incStat(1, 'turns_number');
-        } catch ( Exception $e ) {
+        } catch (Exception $e) {
             // logging does not actually work in game init :(
             $this->error("Fatal error while creating game");
             $this->dump('err', $e);
         }
     }
 
-    function debug_initTables() {
+    function debug_initTables()
+    {
         $this->tokens->deleteAll();
         $this->initTables();
         $newGameDatas = $this->getAllTableDatas();
@@ -133,75 +150,52 @@ class EminentDomain extends EuroGame {
         $this->debugConsole("ok");
     }
 
-    function debug_getTokens($type, $location = null, $state = null, $order_by = null) {
+    function debug_getTokens($type, $location = null, $state = null, $order_by = null)
+    {
         return $this->tokens->getTokensOfTypeInLocation($type, $location, $state, $order_by);
     }
-    
-    function debug_a(){
+
+    function debug_a()
+    {
         // random code that I need to execute
         for ($i = 13; $i <= 16; $i++) {
-            $this->dbSetTokenLocation("card_role_colonize_$i","cols");
+            $this->dbSetTokenLocation("card_role_colonize_$i", "cols");
         }
-        
     }
 
-    function initTables() {
-        //srand(null);// XXX!
-        $players = $this->loadPlayersBasicInfos();
+    function initTables()
+    {
         $num = $this->getPlayersNumber();
         $learning_variant = $this->getGameStateValue('learning_variant') == 2;
         $extended_variant = $this->getGameStateValue('extended_variant') == 2 && $num == 3;
-        $scenarios_variant = $this->getGameStateValue('scenarios_variant') == 2;
         $escalation_variant = $this->isEscalationVariant();
         // setup from expansion rules
-        $setupnums = [ ];
-        switch ($num) {
-            case 2 :
-                $setupnums = [ 16,14,16,12,16 ];
-                break;
-            case 3 :
-                if ($extended_variant)
-                    $setupnums = [ 18,15,18,14,18 ];
-                else
-                    $setupnums = [ 20,16,20,16,20 ];
-                break;
-            case 4 :
-                $setupnums = [ 20,16,20,16,20 ];
-                break;
-            case 5 :
-                $setupnums = [ 24,20,24,20,24 ];
-                break;
-            default :
-                $this->warn("bad number of players: $num");
-                $setupnums = [ 16,14,16,12,16 ];
-                break;
-        }
-        $maxvp = 24;
-        if ($num == 5)
-            $maxvp = 32;
+        $setupnums = Setup::BuildDecks($num, $extended_variant);
+        $maxvp = Setup::GetMaxVP($num);
         $this->tokens->createTokensPack("vp_w_{INDEX}", "stock_vp", $maxvp);
-        $this->tokens->createTokensPack("card_role_survey_{INDEX}", "supply_survey", $setupnums [0]);
-        $this->tokens->createTokensPack("card_role_warfare_{INDEX}", "supply_warfare", $setupnums [1]);
-        $this->tokens->createTokensPack("card_role_colonize_{INDEX}", "supply_colonize", $setupnums [2]);
-        $this->tokens->createTokensPack("card_role_produce_{INDEX}", "supply_produce", $setupnums [3]);
-        if ( !$learning_variant)
-            $this->tokens->createTokensPack("card_role_research_{INDEX}", "supply_research", $setupnums [4]);
-        $this->tokens->createTokensPack("card_planet_0_{INDEX}", "supply_planets", 6);
-        $this->tokens->shuffle("supply_planets");
+        $this->tokens->createTokensPack("card_role_survey_{INDEX}", "supply_survey", $setupnums[0]);
+        $this->tokens->createTokensPack("card_role_warfare_{INDEX}", "supply_warfare", $setupnums[1]);
+        $this->tokens->createTokensPack("card_role_colonize_{INDEX}", "supply_colonize", $setupnums[2]);
+        $this->tokens->createTokensPack("card_role_produce_{INDEX}", "supply_produce", $setupnums[3]);
+        if (!$learning_variant) {
+            $this->tokens->createTokensPack("card_role_research_{INDEX}", "supply_research", $setupnums[4]);
+        }
+        $this->tokens->createTokensPack("card_planet_0_{INDEX}", "starting_worlds", 6);
+        $this->tokens->shuffle("starting_worlds");
         if ($escalation_variant) {
             $this->tokens->createTokensPack('card_fleet_b_{INDEX}', "dev_null", $num);
             $this->tokens->createTokensPack('card_fleet_i_{INDEX}', "supply_fleet", $num);
         }
         // TECH
-        if ( !$learning_variant) {
-            foreach ( $this->token_types as $key => $info ) {
+        if (!$learning_variant) {
+            foreach ($this->token_types as $key => $info) {
                 if (startsWith($key, "card_tech")) {
-                    $planettype = $info ['p'] [0];
+                    $planettype = $info['p'][0];
                     $location = "supply_tech_$planettype";
                     $create = true;
-                    if (isset($info ['exp'])) {
+                    if (isset($info['exp'])) {
                         $create = false;
-                        if ($this->isEscalationVariant() && $info ['exp'] == 'E')
+                        if ($this->isEscalationVariant() && $info['exp'] == 'E')
                             $create = true;
                     }
                     if ($create)
@@ -219,61 +213,83 @@ class EminentDomain extends EuroGame {
         $this->tokens->createTokensPack('resource_f_{INDEX}', "stock_resource", 6, 0);
         $this->tokens->createTokensPack('resource_i_{INDEX}', "stock_resource", 6, 0);
         $this->tokens->createTokensPack('resource_s_{INDEX}', "stock_resource", 6, 0);
+
+        // Populate all game components
+        $this->tokens->createTokensPack("card_planet_1_{INDEX}", "supply_planets", 9);
+        $this->tokens->createTokensPack("card_planet_2_{INDEX}", "supply_planets", 9);
+        $this->tokens->createTokensPack("card_planet_3_{INDEX}", "supply_planets", 9);
+        if ($escalation_variant) {
+            $this->tokens->createTokensPack("card_planet_E_{INDEX}", "supply_planets", 15, 1);
+        }
+        $this->tokens->shuffle("supply_planets");
+        if ($learning_variant) {
+            $this->tokens->moveToken("card_planet_1_1", "dev_null");
+            $this->tokens->moveToken("card_planet_1_2", "dev_null");
+            $this->tokens->moveToken("card_planet_1_3", "dev_null");
+        }
+
         // SCENARIOS
         $this->scenarioProcess();
-        $scenario_tokens = [ ];
-        foreach ( $this->token_types as $id => $info ) {
-            $rowtype = $info ['type'];
+        $scenario_tokens = [];
+        foreach ($this->token_types as $id => $info) {
+            $rowtype = $info['type'];
             if (startsWith($rowtype, 'scenario')) {
-                $requiredExpansion = $info ['expR'] ?? 'B';
-                if ($requiredExpansion == 'B' || // basic 
-                ($requiredExpansion == 'E' && $escalation_variant)) {
-                    $scenario_tokens [] = [ 'key' => $id ];
+                $requiredExpansion = $info['expR'] ?? 'B';
+                if (
+                    $requiredExpansion == 'B' || // basic 
+                    ($requiredExpansion == 'E' && $escalation_variant)
+                ) {
+                    $scenario_tokens[] = ['key' => $id];
                 }
             }
         }
+
         $this->tokens->createTokens($scenario_tokens, "scenarios", 0);
-        $this->tokens->shuffle("scenarios");
-        $standard_setup = [ 2,1,2,2,2,1,'','' ];
+    }
+
+    private function setupPlayers()
+    {
+        $players = $this->loadPlayersBasicInfos();
+        $learning_variant = $this->getGameStateValue('learning_variant') == 2;
+        $scenarios_variant = $this->isScenarioVariant();
+        $escalation_variant = $this->isEscalationVariant();
+
+        $standard_setup = [2, 1, 2, 2, 2, 1, '', ''];
         $poli = 1;
-        $scenarios_setup = [ ];
-        foreach ( $players as $player_id => $player_info ) {
-            $color = $player_info ['player_color'];
-            $no = $player_info ['player_no'];
-            if ($escalation_variant)
-                $this->tokens->moveToken("card_fleet_b_${no}", "tableau_${color}", 1);
-            if ($scenarios_variant) {
-                $sc = $this->tokens->pickTokensForLocation(1, "scenarios", "tableau_${color}", 1);
-                $key = $sc [0] ['key'];
-                $scenarios_setup [$player_id] = $this->token_types [$key] ['setup'];
-                $conflicts = $this->token_types [$key] ['conflict'];
-                // remove conflicting scenarios
-                foreach ( $conflicts as $confKey ) {
-                    $this->tokens->moveToken($confKey, 'dev_null');
-                }
-            } else {
-                $scenarios_setup [$player_id] = $standard_setup;
+        $scenarios_setup = [];
+        foreach ($players as $player_id => $player_info) {
+            $color = $player_info['player_color'];
+            $no = $player_info['player_no'];
+            if ($escalation_variant) {
+                $this->tokens->moveToken("card_fleet_b_$no", "tableau_$color", 1);
             }
-            $setup = $scenarios_setup [$player_id];
-            $this->tokens->pickTokensForLocation($setup [0], "supply_survey", "deck_${color}", 0);
-            $this->tokens->pickTokensForLocation($setup [1], "supply_warfare", "deck_${color}", 0);
-            $this->tokens->pickTokensForLocation($setup [2], "supply_colonize", "deck_${color}", 0);
-            $this->tokens->pickTokensForLocation($setup [3], "supply_produce", "deck_${color}", 0);
-            if ( !$learning_variant)
-                $this->tokens->pickTokensForLocation($setup [4], "supply_research", "deck_${color}", 0);
+            if ($scenarios_variant) {
+                $sc = $this->tokens->getTokenOfTypeInLocation('scenario', "tableau_$color");
+                $key = $sc['key'];
+                $scenarios_setup[$player_id] = $this->token_types[$key]['setup'];
+            } else {
+                $scenarios_setup[$player_id] = $standard_setup;
+            }
+            $setup = $scenarios_setup[$player_id];
+            $this->tokens->pickTokensForLocation($setup[0], "supply_survey", "deck_${color}", 0);
+            $this->tokens->pickTokensForLocation($setup[1], "supply_warfare", "deck_${color}", 0);
+            $this->tokens->pickTokensForLocation($setup[2], "supply_colonize", "deck_${color}", 0);
+            $this->tokens->pickTokensForLocation($setup[3], "supply_produce", "deck_${color}", 0);
+            if (!$learning_variant)
+                $this->tokens->pickTokensForLocation($setup[4], "supply_research", "deck_${color}", 0);
             // politics
-            $pol = $setup [5];
+            $pol = $setup[5];
             for ($i = 0; $i < $pol; $i++) {
                 $this->tokens->createToken("card_role_politics_${poli}", "deck_${color}", 0);
                 $poli++;
             }
             // staring tech
             for ($i = 7; $i < count($setup); $i++) {
-                $tech = $setup [$i];
+                $tech = $setup[$i];
                 if ($tech) {
                     if ($tech == 'fighter_B') {
                         $info = $this->tokens->getTokenOfTypeInLocation('fighter_B', 'stock_fighter');
-                        $this->tokens->moveToken($info ['key'], "tableau_$color");
+                        $this->tokens->moveToken($info['key'], "tableau_$color");
                         continue;
                     }
                     if ($tech == 'card_fleet_i') {
@@ -296,7 +312,7 @@ class EminentDomain extends EuroGame {
             $this->tokens->shuffle("deck_${color}");
             $this->tokens->pickTokensForLocation(5, "deck_${color}", "hand_${color}");
             // starting planet
-            $desi_planet = $setup [6];
+            $desi_planet = $setup[6];
             if ($desi_planet) { // if special planet 
                 $info = $this->tokens->getTokenInfo($desi_planet);
                 if ($info)
@@ -306,27 +322,17 @@ class EminentDomain extends EuroGame {
             }
         }
         // we have to do that after the special planet are assigned
-        foreach ( $players as $player_id => $player_info ) {
-            $color = $player_info ['player_color'];
-            $setup = $scenarios_setup [$player_id];
-            $desi_planet = $setup [6];
-            if ( !$desi_planet) { // if not special planet 
-                $this->tokens->pickTokensForLocation(1, "supply_planets", "tableau_${color}", 0);
+        foreach ($players as $player_id => $player_info) {
+            $color = $player_info['player_color'];
+            $setup = $scenarios_setup[$player_id];
+            $desi_planet = $setup[6];
+            if (!$desi_planet) { // if not special planet 
+                $this->tokens->pickTokensForLocation(1, "starting_worlds", "tableau_${color}", 0);
             }
         }
-        $this->tokens->moveAllTokensInLocation("supply_planets", "dev_null");
+        // move to dev_null to remove from the game
+        $this->tokens->moveAllTokensInLocation("starting_worlds", "dev_null");
         $this->tokens->moveAllTokensInLocation("scenarios", "dev_null");
-        $this->tokens->createTokensPack("card_planet_1_{INDEX}", "supply_planets", 9);
-        $this->tokens->createTokensPack("card_planet_2_{INDEX}", "supply_planets", 9);
-        $this->tokens->createTokensPack("card_planet_3_{INDEX}", "supply_planets", 9);
-        if ($escalation_variant)
-            $this->tokens->createTokensPack("card_planet_E_{INDEX}", "supply_planets", 15, 1);
-        $this->tokens->shuffle("supply_planets");
-        if ($learning_variant) {
-            $this->tokens->moveToken("card_planet_1_1", "dev_null");
-            $this->tokens->moveToken("card_planet_1_2", "dev_null");
-            $this->tokens->moveToken("card_planet_1_3", "dev_null");
-        }
     }
 
     /*
@@ -338,38 +344,41 @@ class EminentDomain extends EuroGame {
      * _ when the game starts
      * _ when a player refreshes the game page (F5)
      */
-    protected function getAllDatas() {
+    protected function getAllDatas()
+    {
         $result = parent::getAllDatas();
-        $result ['materials'] = $this->materials;
+        $result['materials'] = $this->materials;
         $players = $this->loadPlayersBasicInfos();
         $learning_variant = $this->getGameStateValue('learning_variant') == 2;
         $extended_variant = $this->getGameStateValue('extended_variant') == 2 && count($players) == 3;
         $extra_turn = $this->getGameStateValue('extra_turn_variant') == 2;
-        $result ['variants'] = array ('learning_variant_on' => $learning_variant,
-                'extended_variant_on' => $extended_variant,'extra_turn_variant_on' => $extra_turn );
+        $result['variants'] = array(
+            'learning_variant_on' => $learning_variant,
+            'extended_variant_on' => $extended_variant, 'extra_turn_variant_on' => $extra_turn
+        );
         $top_planet = $this->tokens->getTokenOnTop('supply_planets');
         if ($top_planet) {
-            $top_planet ['state'] = 0;
-            $result ['tokens'] [$top_planet ['key']] = $top_planet;
+            $top_planet['state'] = 0;
+            $result['tokens'][$top_planet['key']] = $top_planet;
         }
         $current = $this->getCurrentPlayerId();
-        $icons = $this->materials ['role_icons'];
-        foreach ( $players as $player_id => $player_info ) {
-            $color = $player_info ['player_color'];
+        $icons = $this->materials['role_icons'];
+        foreach ($players as $player_id => $player_info) {
+            $color = $player_info['player_color'];
             $ii = $this->arg_iconsInfo($color, $icons);
-            foreach ( $icons as $icon ) {
-                $value = $ii ["perm_boost_num"] [$icon];
-                $this->setCounter($result ['counters'], "iconperm_${icon}_${color}_counter", $value);
+            foreach ($icons as $icon) {
+                $value = $ii["perm_boost_num"][$icon];
+                $this->setCounter($result['counters'], "iconperm_${icon}_${color}_counter", $value);
             }
             $score = count($this->tokens->getTokensOfTypeInLocation('vp', "tableau_$color"));
-            $this->setCounter($result ['counters'], "vp_${color}_counter", $score);
+            $this->setCounter($result['counters'], "vp_${color}_counter", $score);
             if ($current == $player_id)
-                $result ['server_prefs'] = $this->dbGetAllServerPrefs($player_id);
+                $result['server_prefs'] = $this->dbGetAllServerPrefs($player_id);
         }
         $triggered = $this->getGameStateValue('end_of_game');
-        $result ['end_of_game'] = $triggered == 1;
-  
-        
+        $result['end_of_game'] = $triggered == 1;
+
+
         return $result;
     }
 
@@ -383,7 +392,8 @@ class EminentDomain extends EuroGame {
      * This method is called each time we are in a game state with the "updateGameProgression" property set to true
      * (see states.inc.php)
      */
-    function getGameProgression() {
+    function getGameProgression()
+    {
         $this->isEndOfGameTriggered(); // that computes it
         $prog = $this->getGameStateValue('progression');
         return $prog;
@@ -393,13 +403,14 @@ class EminentDomain extends EuroGame {
     //////////// Utility functions
     ////////////    
     // Material utilities
-    function getRulesFor($token_id, $field = 'a') {
+    function getRulesFor($token_id, $field = 'a')
+    {
         $key = $token_id;
-        while ( $key ) {
+        while ($key) {
             //$this->warn("searching for $key|");
             if (array_key_exists($key, $this->token_types)) {
-                if (array_key_exists($field, $this->token_types [$key])) {
-                    return $this->token_types [$key] [$field];
+                if (array_key_exists($field, $this->token_types[$key])) {
+                    return $this->token_types[$key][$field];
                 }
                 return '';
             }
@@ -419,18 +430,19 @@ class EminentDomain extends EuroGame {
      *            - human readable id or name of the token
      * @return string - id of the token found or null if not found
      */
-    function mtGet($hid) {
-        if ( !$hid)
+    function mtGet($hid)
+    {
+        if (!$hid)
             return $hid;
-        if (isset($this->token_types [$hid]))
+        if (isset($this->token_types[$hid]))
             return $hid;
-        foreach ( $this->token_types as $id => $info ) {
-            if (isset($info ['hid']) && $info ['hid'] == $hid) {
+        foreach ($this->token_types as $id => $info) {
+            if (isset($info['hid']) && $info['hid'] == $hid) {
                 return $id;
             }
         }
-        foreach ( $this->token_types as $id => $info ) {
-            if (isset($info ['name']) && strcasecmp($info ['name'], $hid) == 0) {
+        foreach ($this->token_types as $id => $info) {
+            if (isset($info['name']) && strcasecmp($info['name'], $hid) == 0) {
                 return $id;
             }
         }
@@ -454,25 +466,26 @@ class EminentDomain extends EuroGame {
      *            - when true return fall results in array
      * @return string|string[] - return array of ids or single id
      */
-    function mtFind($typePrefix, $field, $value, $exceptId = null, $all = true) {
-        $res = [ ];
-        foreach ( $this->token_types as $id => $info ) {
+    function mtFind($typePrefix, $field, $value, $exceptId = null, $all = true)
+    {
+        $res = [];
+        foreach ($this->token_types as $id => $info) {
             if ($exceptId && $exceptId == $id)
                 continue;
-            $rowtype = $info ['type'];
+            $rowtype = $info['type'];
             if ($typePrefix && startsWith($rowtype, $typePrefix)) {
-                if (isset($info [$field])) {
-                    if (is_array($info [$field])) {
-                        if (in_array($value, $info [$field], true)) {
-                            if ( !$all)
+                if (isset($info[$field])) {
+                    if (is_array($info[$field])) {
+                        if (in_array($value, $info[$field], true)) {
+                            if (!$all)
                                 return $id;
-                            $res [] = $id;
+                            $res[] = $id;
                         }
                     } else {
-                        if ($value === $info [$field]) {
-                            if ( !$all)
+                        if ($value === $info[$field]) {
+                            if (!$all)
                                 return $id;
-                            $res [] = $id;
+                            $res[] = $id;
                         }
                     }
                 }
@@ -481,20 +494,21 @@ class EminentDomain extends EuroGame {
         return $res;
     }
 
-    function mtCollectWithField($field, $callback) {
-        $res = [ ];
-        foreach ( $this->token_types as $id => $info ) {
-            if (isset($info [$field])) {
-                if (is_array($info [$field])) {
-                    foreach ( $info [$field] as $trig ) {
-                        if ($callback($trig,$id)) {
-                            $res [] = $id;
+    function mtCollectWithField($field, $callback)
+    {
+        $res = [];
+        foreach ($this->token_types as $id => $info) {
+            if (isset($info[$field])) {
+                if (is_array($info[$field])) {
+                    foreach ($info[$field] as $trig) {
+                        if ($callback($trig, $id)) {
+                            $res[] = $id;
                         }
                     }
                 } else {
-                    $trig = $info [$field];
-                    if ($callback($trig,$id)) {
-                        $res [] = $id;
+                    $trig = $info[$field];
+                    if ($callback($trig, $id)) {
+                        $res[] = $id;
                     }
                 }
             }
@@ -502,7 +516,8 @@ class EminentDomain extends EuroGame {
         return $res;
     }
 
-    function mtTriggering($event) {
+    function mtTriggering($event)
+    {
         $field = 'trig';
         $callback = function ($v) use ($event) {
             return $this->mtMatchEvent($v, $event);
@@ -525,29 +540,30 @@ class EminentDomain extends EuroGame {
      * @param array $splits
      * @return boolean
      */
-    function mtMatchEvent($trigger_rule, $event, &$splits = [ ]) {
-        if ( !$event)
+    function mtMatchEvent($trigger_rule, $event, &$splits = [])
+    {
+        if (!$event)
             $event = ".-.";
         $woot = explode(":", $trigger_rule, 2);
-        $trig = $woot [0];
+        $trig = $woot[0];
         $out = '';
         if (count($woot) > 1)
-            $out = $woot [1];
+            $out = $woot[1];
         $event_split = explode("-", $event, 2);
         $trig_split = explode("-", $trig, 2);
         $trig_type = array_value_get($trig_split, 0, '.');
         $trig_role = array_value_get($trig_split, 1, '.');
         $event_type = array_value_get($event_split, 0, '.');
         $event_role = array_value_get($event_split, 1, 'x');
-        $splits ['rule_type'] = $trig_type;
-        $splits ['rule_role'] = $trig_role;
-        $splits ['event_type'] = $event_type;
-        $splits ['event_role'] = $event_role;
-        $splits ['out'] = $out;
+        $splits['rule_type'] = $trig_type;
+        $splits['rule_role'] = $trig_role;
+        $splits['event_type'] = $event_type;
+        $splits['event_role'] = $event_role;
+        $splits['out'] = $out;
         $type_match = ($event_type === '.' || $trig_type === $event_type || preg_match("/^${trig_type}$/", $event_type) === 1);
         $role_match = ($event_role === '.' || $trig_role === $event_role || preg_match("/^${trig_role}$/", $event_role) === 1);
-        $splits ['match_type'] = $type_match;
-        $splits ['match_role'] = $role_match;
+        $splits['match_type'] = $type_match;
+        $splits['match_role'] = $role_match;
         if ($type_match && $role_match)
             return true;
 
@@ -555,27 +571,29 @@ class EminentDomain extends EuroGame {
         return false;
     }
 
-    function mtTriggerInfo($card, $event) {
-        $triginfo = [ ];
+    function mtTriggerInfo($card, $event)
+    {
+        $triginfo = [];
         $info = $this->getRulesFor($card, 'trig');
-        foreach ( $info as $i => $trig ) {
-            $split = [ ];
+        foreach ($info as $i => $trig) {
+            $split = [];
             if ($this->mtMatchEvent($trig, $event, $split)) {
-                $triginfo = [ 'card' => $card,'num' => $i,'event' => $event,'rules' => $split ['out'] ];
+                $triginfo = ['card' => $card, 'num' => $i, 'event' => $event, 'rules' => $split['out']];
                 break;
             }
         }
         return $triginfo;
     }
 
-    function mtGetFightCost($planet, $field = 'w') {
+    function mtGetFightCost($planet, $field = 'w')
+    {
         if ($field == 'wi') // attack with primary weapon
             $fight = "B";
         else
             $fight = trim($this->getRulesFor($planet, $field));
         if (strlen($fight) == 2) {
-            $mcost = $fight [0];
-            $ftype = $fight [1];
+            $mcost = $fight[0];
+            $ftype = $fight[1];
         } else {
             $mcost = $fight;
             $ftype = 'F'; // ship type
@@ -584,13 +602,14 @@ class EminentDomain extends EuroGame {
             $ftype = $mcost;
             $mcost = 1;
         } else {
-            $mcost = ( int ) $mcost; // military cost
+            $mcost = (int) $mcost; // military cost
         }
-        $ship = $this->materials ['icons'] [$ftype]; // ship name
-        return [ 'cost' => $mcost,'ship_type' => $ftype,'ship_name' => $ship,'rule' => str_repeat($ftype, $mcost) ];
+        $ship = $this->materials['icons'][$ftype]; // ship name
+        return ['cost' => $mcost, 'ship_type' => $ftype, 'ship_name' => $ship, 'rule' => str_repeat($ftype, $mcost)];
     }
 
-    function mtIconCount($card, $icon) {
+    function mtIconCount($card, $icon)
+    {
         $cur_icons = $this->getRulesFor($card, 'i');
         $count = substr_count($cur_icons, $icon);
         return $count;
@@ -602,61 +621,64 @@ class EminentDomain extends EuroGame {
      * its should have been there but I cannot really define functions
      * in materil file.
      */
-    function scenarioProcess() {
-        foreach ( $this->token_types as $id => &$info ) {
-            $rowtype = $info ['type'];
+    function scenarioProcess()
+    {
+        foreach ($this->token_types as $id => &$info) {
+            $rowtype = $info['type'];
             if (startsWith($rowtype, 'scenario')) {
-                for ($i = 6; $i <= 9; $i++) {
-                    if ( !isset($info ['setup'] [$i]))
+                for ($i = 6; $i <= 9; $i++) { // Starting world + up to 2 starting techs (this is why we can't have Double Time scenario)
+                    if (!isset($info['setup'][$i]))
                         continue;
-                    $v = $info ['setup'] [$i];
+                    $v = $info['setup'][$i];
                     if ($v == 'random') {
-                        $info ['setup'] [$i] = '';
+                        $info['setup'][$i] = ''; // a '' world is random
                     } else {
                         $v = $this->mtGet($v);
-                        $info ['setup'] [$i] = $v;
+                        $info['setup'][$i] = $v; // get the ID from the world/tech name
                     }
                 }
             }
         }
-        foreach ( $this->token_types as $id => &$info ) {
-            $rowtype = $info ['type'];
+        foreach ($this->token_types as $id => &$info) {
+            $rowtype = $info['type'];
             if (startsWith($rowtype, 'scenario')) {
-                $info ['conflict'] = [ ];
-                for ($i = 6; $i <= 9; $i++) {
-                    if ( !isset($info ['setup'] [$i]))
+                $info['conflict'] = [];
+                for ($i = 6; $i <= 9; $i++) { // Starting world + up to 2 starting techs
+                    if (!isset($info['setup'][$i]))
                         continue;
-                    $v = $info ['setup'] [$i];
-                    if ( !$v || $v == 'random')
+                    $v = $info['setup'][$i];
+                    if (!$v || $v == 'random')
                         continue;
                     $foundarr = $this->mtFind('scenario', 'setup', $v, $id, true);
-                    $info ['conflict'] = array_unique(array_merge($info ['conflict'], $foundarr));
-                    if (isset($this->token_types [$v] ['flip'])) {
-                        $flip = $this->token_types [$v] ['flip'];
+                    $info['conflict'] = array_unique(array_merge($info['conflict'], $foundarr));
+                    if (isset($this->token_types[$v]['flip'])) {
+                        $flip = $this->token_types[$v]['flip'];
                         $foundarr = $this->mtFind('scenario', 'setup', $flip, $id, true);
                         //echo "FLIP $id: $i $v $flip ;\n";
-                        $info ['conflict'] = array_unique(array_merge($info ['conflict'], $foundarr));
+                        $info['conflict'] = array_unique(array_merge($info['conflict'], $foundarr));
                     }
                 }
             }
         }
     }
-    
+
     // End of Material utilities
-    
-    function iconReplacement(&$jokers, $icons, $event, $rules) {
-        $split = [ ];
+
+    function iconReplacement(&$jokers, $icons, $event, $rules)
+    {
+        $split = [];
         if ($this->mtMatchEvent($rules, $event, $split)) {
-            $rolematch = $split ['rule_role'];
-            foreach ( $icons as $icon ) {
+            $rolematch = $split['rule_role'];
+            foreach ($icons as $icon) {
                 if (preg_match("/$rolematch/", $icon)) {
-                    $jokers [$icon] .= $split ['out'];
+                    $jokers[$icon] .= $split['out'];
                 }
             }
         }
         //$this->debugConsole("irep",[$jokers, $icons, $event, $rules]);
     }
-    function isReadyToBeSettled($planet, $perm_boost) {
+    function isReadyToBeSettled($planet, $perm_boost)
+    {
         $colonies = $this->getRulesFor($planet, 'c');
         $this->systemAssertTrue("bad planet $planet", $colonies);
         $tokens = $this->tokens->getTokensInLocation($planet);
@@ -666,7 +688,8 @@ class EminentDomain extends EuroGame {
         return false;
     }
 
-    function isPermanentTech($tech) {
+    function isPermanentTech($tech)
+    {
         $side = $this->getRulesFor($tech, 'side');
         if ($side == '1' || $side == '2')
             return true;
@@ -677,25 +700,28 @@ class EminentDomain extends EuroGame {
         return false;
     }
 
-    function isActionable($card) {
+    function isActionable($card)
+    {
         $action = $this->getRulesFor($card, 'a');
-        if ( !$action || $action === '*')
+        if (!$action || $action === '*')
             return false;
         return true;
     }
 
-    function isPlanet($card) {
+    function isPlanet($card)
+    {
         return startsWith($card, 'card_planet');
     }
 
-    function isEndOfGameTriggered() {
+    function isEndOfGameTriggered()
+    {
         $triggered = $this->getGameStateValue('end_of_game');
         if ($triggered)
             return true;
         $players = $this->loadPlayersBasicInfos();
         $num = $this->getPlayersNumber();
         $total = 0;
-        foreach ( $players as $player_id => $player_info ) {
+        foreach ($players as $player_id => $player_info) {
             $color = $this->getPlayerColor($player_id);
             $score = count($this->tokens->getTokensOfTypeInLocation('vp', "tableau_$color"));
             $total += $score;
@@ -710,9 +736,9 @@ class EminentDomain extends EuroGame {
         }
         $prox1 = $total * 100 / ($max);
         $learning_variant = $this->getGameStateValue('learning_variant') == 2;
-        $supplies = [ 'supply_survey','supply_warfare','supply_colonize','supply_produce' ];
-        if ( !$learning_variant) {
-            $supplies [] = 'supply_research';
+        $supplies = ['supply_survey', 'supply_warfare', 'supply_colonize', 'supply_produce'];
+        if (!$learning_variant) {
+            $supplies[] = 'supply_research';
         }
         $extended_variant = ($this->getGameStateValue('extended_variant') == 2 && $num == 3) || $num > 3;
         $empty_decks = 1;
@@ -720,7 +746,7 @@ class EminentDomain extends EuroGame {
             $empty_decks = 2;
         $ctot = count($supplies) * 16;
         $rtot = 0;
-        foreach ( $supplies as $location ) {
+        foreach ($supplies as $location) {
             $count = $this->tokens->countTokensInLocation($location);
             if ($count <= 0)
                 $empty_decks--;
@@ -734,24 +760,26 @@ class EminentDomain extends EuroGame {
         $prox2 = ($ctot - $rtot) * 100 / $ctot;
         if ($prox2 > $prox1)
             $prox1 = $prox2;
-        $this->setGameStateValue('progression', ( int ) $prox1);
+        $this->setGameStateValue('progression', (int) $prox1);
         return false;
     }
-    
-    function checkTooManyCardsInHand($color, $bThrow = true) {
+
+    function checkTooManyCardsInHand($color, $bThrow = true)
+    {
         $count = $this->tokens->countTokensInLocation("hand_$color");
-        $iconsinfo = $this->arg_iconsInfo($color, [ 'h' ]);
-        $max = $iconsinfo ['hand_size'];
+        $iconsinfo = $this->arg_iconsInfo($color, ['h']);
+        $max = $iconsinfo['hand_size'];
         if ($count > $max) {
             if ($bThrow)
                 $this->userAssertTrue(self::_("You must discard down to $max cards"));
-                else
-                    return $max;
+            else
+                return $max;
         }
         return 0;
     }
 
-    function isEndOfGame($next_player_id) {
+    function isEndOfGame($next_player_id)
+    {
         if ($this->getFirstPlayer() == $next_player_id) {
             if ($this->isEndOfGameTriggered()) {
                 return true;
@@ -760,65 +788,67 @@ class EminentDomain extends EuroGame {
         return false;
     }
 
-    function finalScoring() {
+    function finalScoring()
+    {
         $players = $this->loadPlayersBasicInfos();
-        foreach ( $players as $player_id => $player_info ) {
+        foreach ($players as $player_id => $player_info) {
             $res_count = 0;
-            $color = $player_info ['player_color'];
-            $no = $player_info ['player_no'];
+            $color = $player_info['player_color'];
+            $no = $player_info['player_no'];
             $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "tableau_${color}");
-            foreach ( $tokens as $planet => $info ) {
-                $state = $info ['state'];
+            foreach ($tokens as $planet => $info) {
+                $state = $info['state'];
                 if ($state == 1) {
                     // colonized
                     $restokens = $this->tokens->getTokensOfTypeInLocation("resource", $planet);
                     $res_count += count($restokens);
                 } else {
                     $ptokens = $this->tokens->getTokensInLocation($planet);
-                    foreach ( $ptokens as $key => $info ) {
-                        $this->dbSetTokenLocation($key, "tableau_$color", 0, '', [ 'nod' => true ]);
+                    foreach ($ptokens as $key => $info) {
+                        $this->dbSetTokenLocation($key, "tableau_$color", 0, '', ['nod' => true]);
                     }
                 }
             }
             $this->tokens->moveAllTokensInLocation("hand_${color}", "deck_${color}");
             $this->tokens->moveAllTokensInLocation("discard_${color}", "deck_${color}");
             $tokens = $this->tokens->getTokensOfTypeInLocation("card_tech_2", "%_${color}");
-            foreach ( $tokens as $token_id => $info ) {
+            foreach ($tokens as $token_id => $info) {
                 $this->dbSetTokenLocation($token_id, "tableau_${color}", 0, '');
             }
             $tokens = $this->tokens->getTokensOfTypeInLocation("card_tech_3", "%_${color}");
-            foreach ( $tokens as $token_id => $info ) {
+            foreach ($tokens as $token_id => $info) {
                 $this->dbSetTokenLocation($token_id, "tableau_${color}", 0, '');
             }
             $this->notifyAnimate();
             // reveal the rest
             $tokens = $this->tokens->getTokensOfTypeInLocation("card", "deck_${color}");
-            foreach ( $tokens as $token_id => $info ) {
-                $this->dbSetTokenLocation($token_id, "tableau_${color}", 0, '', [ 'nod' => true ]);
+            foreach ($tokens as $token_id => $info) {
+                $this->dbSetTokenLocation($token_id, "tableau_${color}", 0, '', ['nod' => true]);
             }
             $tokens = $this->tokens->getTokensOfTypeInLocation('fighter', "tableau_$color");
-            $fighter=0;
-            foreach ( $tokens as $token_id => $info ) {
-                if (getPart($token_id, 1)==='B') { // Battlecruiser 2 points
+            $fighter = 0;
+            foreach ($tokens as $token_id => $info) {
+                if (getPart($token_id, 1) === 'B') { // Battlecruiser 2 points
                     $this->dbIncScoreValueAndNotify($player_id, 2, clienttranslate('${player_name} scored 2 influence for Battlecruiser'));
                 }
-                if (getPart($token_id, 1)==='F') {
+                if (getPart($token_id, 1) === 'F') {
                     $fighter++;
                 }
             }
-            $tokensF = $this->tokens->getTokensOfTypeInLocation('fighter_F', null,$player_id);
-            
-            $fighter+=count($tokensF);
+            $tokensF = $this->tokens->getTokensOfTypeInLocation('fighter_F', null, $player_id);
+
+            $fighter += count($tokensF);
             $this->dbSetAuxScore($player_id, $fighter + $res_count);
-            
+
             $this->setStat($this->dbGetScore($player_id), 'game_vp', $player_id);
         }
     }
-    
+
     /**
      * This only should be use for dinamic markers
      */
-    function dbMoveOrCreate($id, $location, $state) {
+    function dbMoveOrCreate($id, $location, $state)
+    {
         $info = $this->tokens->getTokenInfo($id);
         if ($info) {
             $this->tokens->moveToken($id, $location, $state);
@@ -828,14 +858,15 @@ class EminentDomain extends EuroGame {
     }
 
 
-    function dbGetFreeResourceInfo($resource) {
+    function dbGetFreeResourceInfo($resource)
+    {
         switch ($resource) {
-            case 'f' :
-            case 'w' :
-            case 'i' :
-            case 's' :
+            case 'f':
+            case 'w':
+            case 'i':
+            case 's':
                 break;
-            default :
+            default:
                 $this->systemAssertTrue("Invalid resource type $resource");
                 break;
         }
@@ -844,42 +875,46 @@ class EminentDomain extends EuroGame {
         return $this->dbGetAutoIncToken($restype, $location, 6, 1, true);
     }
 
-    function dbSetMarkerLocation($key, $location, $state) {
+    function dbSetMarkerLocation($key, $location, $state)
+    {
         $info = $this->dbGetAutoIncToken($key, 'pending_stock', 1, 1, false);
-        $this->tokens->moveToken($info ['key'], $location, $state);
+        $this->tokens->moveToken($info['key'], $location, $state);
         //$this->debugConsole('marker created ${token_name} ${place_name}', ['token_name'=>$info['key'], 'place_name'=>$location]);
     }
 
-    function dbGetOwnVpInfo($color) {
+    function dbGetOwnVpInfo($color)
+    {
         $resa = $this->tokens->getTokensOfTypeInLocation('vp', "tableau_${color}");
         return $resa;
     }
 
-    function dbGetOwnFighterInfo($color, $includeHand = true) {
-        $rec = [ 'F' => [ ],'D' => [ ],'B' => [ ] ];
+    function dbGetOwnFighterInfo($color, $includeHand = true)
+    {
+        $rec = ['F' => [], 'D' => [], 'B' => []];
         $resa = $this->tokens->getTokensOfTypeInLocation('fighter', "tableau_${color}");
-        foreach ( $resa as $key => $info ) {
+        foreach ($resa as $key => $info) {
             $type = getPart($key, 1);
-            $rec [$type] [] = $key;
+            $rec[$type][] = $key;
         }
         $resa = $this->tokens->getTokensOfTypeInLocation('fighter', null, $this->getPlayerIdByColor($color));
-        foreach ( $resa as $key => $info ) {
+        foreach ($resa as $key => $info) {
             $type = getPart($key, 1);
-            $rec [$type] [] = $key;
+            $rec[$type][] = $key;
         }
         if ($includeHand) {
             $resa = $this->tokens->getTokensOfTypeInLocation('card', "hand_${color}");
-            foreach ( $resa as $key => $info ) {
+            foreach ($resa as $key => $info) {
                 $type = $this->getRulesFor($key, 'asf'); // card as ships
-                if ( !$type)
+                if (!$type)
                     continue;
-                $rec [$type] [] = $key;
+                $rec[$type][] = $key;
             }
         }
         return $rec;
     }
 
-    function getAllActivePermanents($color) {
+    function getAllActivePermanents($color)
+    {
         $loc = "tableau_${color}";
         $tech = $this->tokens->getTokensOfTypeInLocation("card_tech", $loc, 1);
         $planets = $this->tokens->getTokensOfTypeInLocation("card_planet", $loc, 1);
@@ -888,19 +923,20 @@ class EminentDomain extends EuroGame {
         return $res;
     }
 
-    function dbGetFreeFighterInfo($resource = 'F', $requested = 1, $array = false) {
+    function dbGetFreeFighterInfo($resource = 'F', $requested = 1, $array = false)
+    {
         $max = $requested;
         switch ($resource) {
-            case 'F' :
+            case 'F':
                 $max += 10;
                 break;
-            case 'D' :
+            case 'D':
                 $max += 5;
                 break;
-            case 'B' :
+            case 'B':
                 $max += 2;
                 break;
-            default :
+            default:
                 $this->systemAssertTrue("Invalid figher type $resource");
                 break;
         }
@@ -909,7 +945,8 @@ class EminentDomain extends EuroGame {
         return $this->dbGetAutoIncToken($restype, $location, $max, $requested, true, $array);
     }
 
-    function dbGetAutoIncToken($restype, $location, $max = -1, $requested = 1, $syncDb = true, $array = false) {
+    function dbGetAutoIncToken($restype, $location, $max = -1, $requested = 1, $syncDb = true, $array = false)
+    {
         if ($max <= 0 || $max < $requested + 1)
             $max = $requested + 1;
         $resa = $this->tokens->getTokensOfTypeInLocation($restype, $location);
@@ -917,10 +954,10 @@ class EminentDomain extends EuroGame {
         $num = $max - $count;
         if ($num > 0) {
             // re-stock
-            $keys = [ ];
+            $keys = [];
             for ($i = 0; $i < $num; $i++) {
                 $suf = $this->tokens->createTokenAutoInc($restype, $location);
-                $keys [] = $suf;
+                $keys[] = $suf;
             }
             if ($syncDb)
                 $this->dbSyncInfo($keys);
@@ -932,7 +969,8 @@ class EminentDomain extends EuroGame {
             return array_slice($resa, 0, $requested, true);
     }
 
-    function dbGetFreeVpTokens($num = 1) {
+    function dbGetFreeVpTokens($num = 1)
+    {
         $resa = $this->tokens->getTokensInLocation("stock_vp");
         while (count($resa) < $num) {
             // create blue token
@@ -944,44 +982,47 @@ class EminentDomain extends EuroGame {
         return array_slice($resa, 0, $num, true);
     }
 
-    function getCardOwnerColor($card_id) {
+    function getCardOwnerColor($card_id)
+    {
         $info = $this->tokens->getTokenInfo($card_id);
-        $loc = $info ['location'];
+        $loc = $info['location'];
         $color = getPart($loc, 1, true);
         return $color;
     }
 
-    function playerHasCard($card_id, $color, $ignore_used = false) {
+    function playerHasCard($card_id, $color, $ignore_used = false)
+    {
         $info = $this->tokens->getTokenInfo($card_id);
         if (!$info) {
             $this->warn("Cannot find card $card_id");
             return false;
         }
         if ($this->isPlanet($card_id) || startsWith($card_id, 'scenario')) {
-            if ($info ['location'] !== "tableau_${color}")
+            if ($info['location'] !== "tableau_${color}")
                 return false;
-            if ($info ['state'] == 0)
+            if ($info['state'] == 0)
                 return false;
             return $card_id;
         }
         if ($this->isPermanentTech($card_id)) {
-            if ($info ['location'] !== "tableau_${color}")
+            if ($info['location'] !== "tableau_${color}")
                 return false;
-            if ($info ['state'] == 0 && !$ignore_used)
+            if ($info['state'] == 0 && !$ignore_used)
                 return false;
         } else {
-            if ($info ['location'] !== "setaside_${color}")
+            if ($info['location'] !== "setaside_${color}")
                 return false;
-            if ($info ['state'] != CARD_STATE_TURN_LASTING)
+            if ($info['state'] != CARD_STATE_TURN_LASTING)
                 return false;
         }
         return $card_id;
     }
 
-    function getIconCount($icon, $tokens, $jokers='') {
+    function getIconCount($icon, $tokens, $jokers = '')
+    {
         $keys = $this->tokens->toTokenKeyList($tokens);
         $boost = 0;
-        foreach ( $keys as $card ) {
+        foreach ($keys as $card) {
             $count = $this->mtIconCount($card, $icon);
             if (!$count && $jokers === '*')
                 $count = 1;
@@ -1019,19 +1060,23 @@ class EminentDomain extends EuroGame {
         return $boost;
     }
 
-    function getSettleBoost($color) {
+    function getSettleBoost($color)
+    {
         $tokens_perm = $this->tokens->getTokensOfTypeInLocation("card", "tableau_${color}", 1);
         return $this->getIconCount('C', $tokens_perm);
     }
 
-    function revealPlanetSupplyTop() {
+    function revealPlanetSupplyTop()
+    {
         $place_id = "supply_planets";
         $top = $this->tokens->getTokenOnTop($place_id, false);
         if ($top != null) {
-            $token_id = $top ['key'];
+            $token_id = $top['key'];
             // reveal back of top card in the supply
-            $this->notifyWithName("tokenMoved", '', array ('token_id' => $token_id,'place_id' => $place_id,
-                    'token_name' => $token_id,'place_name' => $place_id,'new_state' => 0 ));
+            $this->notifyWithName("tokenMoved", '', array(
+                'token_id' => $token_id, 'place_id' => $place_id,
+                'token_name' => $token_id, 'place_name' => $place_id, 'new_state' => 0
+            ));
         }
         $this->notifyCounter("supply_planets");
         $this->notifyCounter("discard_planets");
@@ -1044,13 +1089,16 @@ class EminentDomain extends EuroGame {
      * @param string $other - target card id or other argument of ability
      * @param int $num - type of rule
      */
-    function pushAbility($color, $card_id, $other, $num) {
+    function pushAbility($color, $card_id, $other, $num)
+    {
         $player_id = $this->getPlayerIdByColor($color);
 
         $rules = $this->getRulesByNum($card_id, $num);
         $notif = clienttranslate('game activates triggered effects of ${token_name}');
-        $this->notifyWithName('playerLog', $notif, [ 'player_id' => $player_id,'token_id' => $card_id,
-                'token_name' => $card_id ]);
+        $this->notifyWithName('playerLog', $notif, [
+            'player_id' => $player_id, 'token_id' => $card_id,
+            'token_name' => $card_id
+        ]);
         if ($this->saction_AutoPerform($color, $card_id, $rules)) {
             return;
         }
@@ -1063,28 +1111,30 @@ class EminentDomain extends EuroGame {
             $this->dbMoveOrCreate("abi_target_${cur}", $other, $cur); // marker indicating target card, if trigger had it
     }
 
-    function peekAbility() {
+    function peekAbility()
+    {
         return $this->popAbility(true);
     }
 
-    function popAbility($peek = false) {
+    function popAbility($peek = false)
+    {
         // pull all triggered abilities from all cards sort in stack order (state is order)
         $abi_stack = $this->tokens->getTokensOfTypeInLocation("abi_p_", null, "!=-1", "token_state DESC");
         $top = array_shift($abi_stack);
         if ($top == null)
             return null; // nothing on stack
         //$this->warn(toJson($top));
-        $cur = $top ['state'];
-        $topkey = $top ['key'];//"abi_p_${num}_${color}_${cur}"
-        $card_id = $top ['location'];
+        $cur = $top['state'];
+        $topkey = $top['key']; //"abi_p_${num}_${color}_${cur}"
+        $card_id = $top['location'];
         $num = getPart($topkey, 2);
         $color = getPart($topkey, 3);
         $target_info = $this->tokens->getTokenInfo("abi_target_${cur}");
         // reconstruct trigger info from the ability
         $rules = $this->getRulesByNum($card_id, $num);
-        $triginfo = [ 'card' => $card_id,'num' => $num,'rules' => $rules,'actor_color' => $color ];
+        $triginfo = ['card' => $card_id, 'num' => $num, 'rules' => $rules, 'actor_color' => $color];
         if ($target_info)
-            $triginfo ['other'] = $target_info ['location'];
+            $triginfo['other'] = $target_info['location'];
         if ($peek == false) {
             $this->tokens->moveToken($topkey, 'dev_null', -1);
             if ($target_info) {
@@ -1093,15 +1143,16 @@ class EminentDomain extends EuroGame {
         }
         return $triginfo;
     }
-    
-    function getRulesByNum($card_id, $num) {
+
+    function getRulesByNum($card_id, $num)
+    {
         $rules = '';
         if ($num < 20) { // first 20 reserved for triggered abilities
             $trigarr = $this->getRulesFor($card_id, 'trig');
             if ($trigarr) {
-                $trig = $trigarr [$num];
+                $trig = $trigarr[$num];
                 $woot = explode(":", $trig, 2);
-                $rules = $woot [1];
+                $rules = $woot[1];
             }
         } else if ($num == CARD_RULE_SPECIAL) {
             $rules = $this->getRulesFor($card_id, 'special');
@@ -1124,38 +1175,40 @@ class EminentDomain extends EuroGame {
         return $rules;
     }
 
-    function consumeOperation(&$rules, $consume, $replace = '') {
+    function consumeOperation(&$rules, $consume, $replace = '')
+    {
         $hit = false;
         $rules_a = explode('/', $rules);
-        foreach ( $rules_a as $i => $clause ) {
-            if ( !$clause) {
-                unset($rules_a [$i]);
+        foreach ($rules_a as $i => $clause) {
+            if (!$clause) {
+                unset($rules_a[$i]);
                 continue;
             }
             if (startsWith($clause, $consume)) {
-                $rules_a [$i] = substr($clause, 1) . $replace;
+                $rules_a[$i] = substr($clause, 1) . $replace;
                 $hit = true;
             } else {
-                unset($rules_a [$i]); // choice is eliminated
+                unset($rules_a[$i]); // choice is eliminated
             }
         }
         $rules = implode('/', array_values($rules_a));
         return $hit;
     }
 
-    function fillSlot(&$slotsarr, $restype, $target = null) {
+    function fillSlot(&$slotsarr, $restype, $target = null)
+    {
         if ($target == null)
             $target = $restype;
-        if ( !array_key_exists($target, $slotsarr)) {
+        if (!array_key_exists($target, $slotsarr)) {
             if ($target != 'n') { // any
                 return $this->fillSlot($slotsarr, $restype, 'n');
             }
             return false;
         }
-        $mod = count($slotsarr [$target]);
+        $mod = count($slotsarr[$target]);
         for ($j = 0; $j < $mod; $j++) {
-            if ($slotsarr [$target] [$j] === 0) {
-                $slotsarr [$target] [$j] = $restype; // fill the slot
+            if ($slotsarr[$target][$j] === 0) {
+                $slotsarr[$target][$j] = $restype; // fill the slot
                 return true;
             }
         }
@@ -1167,42 +1220,45 @@ class EminentDomain extends EuroGame {
         }
     }
 
-    function debugConsole($info, $args = array ()) {
-        $this->notifyAllPlayers("log", '', [ 'log' => $info,'args' => $args ]);
+    function debugConsole($info, $args = array())
+    {
+        $this->notifyAllPlayers("log", '', ['log' => $info, 'args' => $args]);
         $this->warn($info);
     }
 
     // Debug from chat: launch a PHP method of the current game for debugging purpose
-    function debugChat($message) {
-        $res=[];
+    function debugChat($message)
+    {
+        $res = [];
         preg_match("/^(.*)\((.*)\)$/", $message, $res);
         if (count($res) == 3) {
-            $method = $res [1];
-            $args = explode(',', $res [2]);
+            $method = $res[1];
+            $args = explode(',', $res[2]);
             foreach ($args as &$value) {
-                if ($value==='null') {
-                    $value=null;
-                } else if ($value==='[]') {
-                    $value=[];
+                if ($value === 'null') {
+                    $value = null;
+                } else if ($value === '[]') {
+                    $value = [];
                 }
             }
             if (method_exists($this, $method)) {
-                self::notifyAllPlayers('simplenotif', "DEBUG: calling $message", [ ]);
-                $ret = call_user_func_array(array ($this,$method ), $args);
+                self::notifyAllPlayers('simplenotif', "DEBUG: calling $message", []);
+                $ret = call_user_func_array(array($this, $method), $args);
                 if ($ret !== null)
                     $this->debugConsole("RETURN: $method ->", $ret);
                 return true;
             } else {
-                self::notifyPlayer($this->getCurrentPlayerId(), 'simplenotif', "DEBUG: running $message; Error: method $method() does not exists", [ ]);
+                self::notifyPlayer($this->getCurrentPlayerId(), 'simplenotif', "DEBUG: running $message; Error: method $method() does not exists", []);
                 return true;
             }
         }
         return false;
     }
-    
-    function next_ActionDispatch($player_id) {
+
+    function next_ActionDispatch($player_id)
+    {
         $args = $this->arg_playerTurnExtra($player_id);
-        if ($args ['enabled']) {
+        if ($args['enabled']) {
             //$this->debugConsole("extra enabled for $player_id", $args);
             $this->gamestate->nextState('loopback');
             return;
@@ -1211,16 +1267,17 @@ class EminentDomain extends EuroGame {
         if ($this->getGameStateValue('action_played') < $this->getGameStateValue('actions_allowed')) {
             $this->gamestate->nextState('loopback');
         } else if ($rolePlayed > 0) { // role already played
-            $this->gamestate->nextState('last');//upkeep
+            $this->gamestate->nextState('last'); //upkeep
         } else {
-            $this->gamestate->nextState('next');//role
+            $this->gamestate->nextState('next'); //role
         }
     }
 
-    function next_RoleDispatch($player_id) {
+    function next_RoleDispatch($player_id)
+    {
         $multi = $this->isMultiActive();
         $args = $this->arg_playerTurnExtra($player_id);
-        if ($args ['enabled']) {
+        if ($args['enabled']) {
             //$this->debugConsole("extra enabled for $player_id", $args);
             if ($multi)
                 $this->gamestate->changeActivePlayer($player_id);
@@ -1242,7 +1299,7 @@ class EminentDomain extends EuroGame {
                 }
             }
             $leader = $this->getGameStateValue('leader');
-            if ($leader == $player_id && $this->getUntrivialDiscardOrActivate($color) && !$discardPlayed && $rolePlayed >= $roleAllowerd ) {
+            if ($leader == $player_id && $this->getUntrivialDiscardOrActivate($color) && !$discardPlayed && $rolePlayed >= $roleAllowerd) {
                 $this->gamestate->nextState('discard'); // pre-discard
                 return;
             }
@@ -1250,8 +1307,9 @@ class EminentDomain extends EuroGame {
 
         $this->gamestate->nextState('next'); // follow
     }
-    
-    function next_StateDispatch($player_id) {
+
+    function next_StateDispatch($player_id)
+    {
         $stateName = $this->getStateName();
         if ($stateName === "playerTurnAction") {
             $this->next_ActionDispatch($player_id);
@@ -1267,7 +1325,8 @@ class EminentDomain extends EuroGame {
      * Each time a player is doing some game action, one of the methods below is called.
      * (note: each method below must match an input method in eminentdomain.action.php)
      */
-    function action_playRole($role, $card, $boost, $choices) {
+    function action_playRole($role, $card, $boost, $choices)
+    {
         self::checkAction('playRole');
         $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
@@ -1276,17 +1335,18 @@ class EminentDomain extends EuroGame {
         $this->setGameStateValue('followers', 0);
         $this->setGameStateValue('followers_waiting', 0);
         $this->setGameStateValue('follow_played', 0);
-        
+
         $this->next_RoleDispatch($player_id);
     }
 
-    function action_playFollow($boost, $choices) {
+    function action_playFollow($boost, $choices)
+    {
         self::checkAction('playFollow');
-        $player_id = $this->getCurrentPlayerId(); 
+        $player_id = $this->getCurrentPlayerId();
         //$leader_id = $this->getGameStateValue('leader');
         $color = $this->getPlayerColor($player_id);
         $role_index = $this->getGameStateValue('role');
-        $role = $this->materials ['role_icons'] [$role_index];
+        $role = $this->materials['role_icons'][$role_index];
         $active_follower = $this->getGameStateValue('active_follower');
         if ($role == 'S' || $role == 'R') {
             $this->userAssertTrue(clienttranslate("Cannot Follow out of order for Survey or Research roles"), $player_id == $active_follower);
@@ -1296,7 +1356,8 @@ class EminentDomain extends EuroGame {
         $this->next_RoleDispatch($player_id);
     }
 
-    function action_playAction($card, $choices, $actnum) {
+    function action_playAction($card, $choices, $actnum)
+    {
         self::checkAction('playAction');
         $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
@@ -1306,7 +1367,8 @@ class EminentDomain extends EuroGame {
 
 
 
-    function action_playActivatePermanent($card, $choices) {
+    function action_playActivatePermanent($card, $choices)
+    {
         self::checkAction('playActivatePermanent');
         $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
@@ -1324,47 +1386,53 @@ class EminentDomain extends EuroGame {
         $this->next_StateDispatch($player_id);
     }
 
-    function action_playPick($card) {
+    function action_playPick($card)
+    {
         self::checkAction('playPick');
         $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
         // $check card
         $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "hand_$color");
         $this->systemAssertTrue("Bad card for pick", array_key_exists($card, $tokens));
-        $this->notifyWithName('playerLog', clienttranslate('You picked ${token_name}'), [ '_private' => true,
-                'token_id' => $card,'token_name' => $card ]);
+        $this->notifyWithName('playerLog', clienttranslate('You picked ${token_name}'), [
+            '_private' => true,
+            'token_id' => $card, 'token_name' => $card
+        ]);
         $this->dbSetTokenLocation($card, "tableau_$color", PLANET_UNSETTLED, clienttranslate('${player_name} picked a planet'));
-        foreach ( $tokens as $planet => $info ) {
+        foreach ($tokens as $planet => $info) {
             if ($planet !== $card)
                 $this->dbSetTokenLocation($planet, "discard_planets", 1, ''); //clienttranslate('${player_name} discards planet ${token_name}')
         }
         $this->next_StateDispatch($player_id);
     }
 
-    function action_playExtra($choices) {
+    function action_playExtra($choices)
+    {
         self::checkAction('playExtra');
-        
+
         $player_id = $this->getMostlyActivePlayerId();
         $color = $this->getPlayerColor($player_id);
         $pending_info = $this->popAbility();
-        $rules = $pending_info ['rules'];
-        $card = $pending_info ['card'];
+        $rules = $pending_info['rules'];
+        $card = $pending_info['card'];
         $this->saction_ExecuteRules($card, $color, $choices, $rules, false);
         $this->saction_ValidateRestOfChoices($choices, $rules);
         $this->next_StateDispatch($player_id);
     }
 
-    function action_playDiscard($choices) {
+    function action_playDiscard($choices)
+    {
         self::checkAction('playDiscard');
         $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
         // $check card
         $choices = trim($choices);
-        $choices_arr = $choices ? explode(' ', $choices) : [ ];
-        foreach ( $choices_arr as $card ) {
-            $this->dbSetTokenLocation($card, "discard_$color", 0, clienttranslate('${player_name} discards ${token_name}'), [ 
-                    'nod' => true ]);
-        }  
+        $choices_arr = $choices ? explode(' ', $choices) : [];
+        foreach ($choices_arr as $card) {
+            $this->dbSetTokenLocation($card, "discard_$color", 0, clienttranslate('${player_name} discards ${token_name}'), [
+                'nod' => true
+            ]);
+        }
         $this->checkTooManyCardsInHand($color);
         if (count($choices_arr) > 0)
             $this->notifyAnimate();
@@ -1374,7 +1442,8 @@ class EminentDomain extends EuroGame {
 
 
 
-    function action_skipAction() {
+    function action_skipAction()
+    {
         self::checkAction('skipAction');
         $this->notifyWithName('playerLog', clienttranslate('${player_name} skips ACTION'));
         $role = $this->getGameStateValue('role');
@@ -1385,14 +1454,16 @@ class EminentDomain extends EuroGame {
         }
     }
 
-    function action_playDissent() {
+    function action_playDissent()
+    {
         self::checkAction('playDissent');
         $player_id = $this->getCurrentPlayerId();
         $this->action_playDissentGame($player_id);
         $this->next_RoleDispatch($player_id);
     }
-    
-    function action_playDissentGame($player_id) {
+
+    function action_playDissentGame($player_id)
+    {
         $color = $this->getPlayerColor($player_id);
         $this->setPlayerMask($player_id, 'followers');
         $this->notifyWithName('playerLog', clienttranslate('${player_name} dissents'), null, $player_id);
@@ -1404,14 +1475,15 @@ class EminentDomain extends EuroGame {
         }
         // triggered ability
         $role_index = $this->getGameStateValue('role');
-        $role = $this->materials ['role_icons'] [$role_index];
+        $role = $this->materials['role_icons'][$role_index];
         $this->saction_TriggerAbilities("d-$role", $color, null);
         $this->dbIncStatChecked(1, "game_dissent", $player_id);
     }
 
-    function action_playWait() {
+    function action_playWait()
+    {
         self::checkAction('playWait');
-  
+
         if ($this->getStateName() == 'playerTurnPreDiscard') {
             $this->gamestate->nextState('next');
             return;
@@ -1424,7 +1496,8 @@ class EminentDomain extends EuroGame {
         $this->gamestate->setPlayerNonMultiactive($player_id, 'next');
     }
 
-    function action_changePreference($pref, $value) {
+    function action_changePreference($pref, $value)
+    {
         // anytime action, no checks
         $player_id = $this->getCurrentPlayerId();
         $color = $this->getPlayerColor($player_id);
@@ -1434,77 +1507,81 @@ class EminentDomain extends EuroGame {
         $this->dbSetPref($pref, $color, $value);
     }
 
-    function saction_EndOfTurn($player_id) {
+    function saction_EndOfTurn($player_id)
+    {
         $color = $this->getPlayerColor($player_id);
-            // count point for resource markers
+        // count point for resource markers
         $tokens = $this->tokens->getTokensOfTypeInLocation("resource", null, RESOURCE_STATE_MARKER);
         if (count($tokens) > 0) {
-            $restypes = [ ];
-            foreach ( $tokens as $info ) {
-                $restype = getPart($info ['key'], 1);
-                $loc = $info ['location'];
-                $restypes [$loc] [$restype] = 1;
+            $restypes = [];
+            foreach ($tokens as $info) {
+                $restype = getPart($info['key'], 1);
+                $loc = $info['location'];
+                $restypes[$loc][$restype] = 1;
             }
-            foreach ( $restypes as $card => $arr ) {
+            foreach ($restypes as $card => $arr) {
                 $distinct = count($arr);
                 $eot_rules = $this->getRulesFor($card, 'eot');
                 if ($eot_rules == 'div_r')
                     $this->saction_GainInfluenceTokens($player_id, $distinct, $card); // 1 vp per type
-                else if ($eot_rules == 'max_r')
-                    ; // 1 for max of 1 type - already counted
+                else if ($eot_rules == 'max_r'); // 1 for max of 1 type - already counted
                 else
                     $this->warn("unknown resource type collection for $card");
             }
             $this->notifyAnimate();
         }
-     
-        
+
+
 
         // all players set aside card go to discard
         $players = $this->loadPlayersBasicInfos();
-        foreach ( $players as $player_info ) {
-            $pcolor = $player_info ['player_color'];
+        foreach ($players as $player_info) {
+            $pcolor = $player_info['player_color'];
             $tokens = $this->tokens->getTokensOfTypeInLocation("card", "setaside_${pcolor}");
-            $this->dbSetTokensLocation($tokens, "discard_${pcolor}", CARD_STATE_FACEUP, '', [ 'nod' => true ]);
+            $this->dbSetTokensLocation($tokens, "discard_${pcolor}", CARD_STATE_FACEUP, '', ['nod' => true]);
             $tokens = $this->tokens->getTokensOfTypeInLocation("resource", "setaside_${pcolor}");
-            $this->dbSetTokensLocation($tokens, 'stock_resource', 0, '', [ 'nod' => true ]);
+            $this->dbSetTokensLocation($tokens, 'stock_resource', 0, '', ['nod' => true]);
             $tokens = $this->tokens->getTokensOfTypeInLocation("fighter", "setaside_${pcolor}");
-            $this->dbSetTokensLocation($tokens, 'stock_fighter', 0, '', [ 'nod' => true ]);
+            $this->dbSetTokensLocation($tokens, 'stock_fighter', 0, '', ['nod' => true]);
         }
         // discard resource markers
         $tokens = $this->tokens->getTokensOfTypeInLocation("resource", null, RESOURCE_STATE_MARKER);
-        $this->dbSetTokensLocation($tokens, 'stock_resource', 0, '', [ 'nod' => true ]);
+        $this->dbSetTokensLocation($tokens, 'stock_resource', 0, '', ['nod' => true]);
         // re-activate tech cards
         $tokens = $this->tokens->getTokensOfTypeInLocation("card_tech", "tableau_${color}", CARD_STATE_PERMANENT_TAPPED);
-        $this->dbSetTokensLocation($tokens, "tableau_${color}", CARD_STATE_PERMANENT, '', [ 'nod' => true ]);
+        $this->dbSetTokensLocation($tokens, "tableau_${color}", CARD_STATE_PERMANENT, '', ['nod' => true]);
 
-           
+
         $this->notifyAnimate();
         $this->notifyAnimate();
         $this->saction_DrawMax($player_id);
     }
 
-    function saction_DrawMax($player_id) {
+    function saction_DrawMax($player_id)
+    {
         $color = $this->getPlayerColor($player_id);
         $count = $this->tokens->countTokensInLocation("hand_$color");
-        $iconsinfo = $this->arg_iconsInfo($color, [ 'h' ]);
-        $max = $iconsinfo ['hand_size'];
+        $iconsinfo = $this->arg_iconsInfo($color, ['h']);
+        $max = $iconsinfo['hand_size'];
         if ($count > $max) {
             $this->notifyWithName('playerLog', '${player_name} has too many cards in hand ${x} out of ${max}', [
-                    'max' => $max,'player_id' => $player_id,'x' => $count ]);
+                'max' => $max, 'player_id' => $player_id, 'x' => $count
+            ]);
             return;
         }
         for ($i = $count; $i < $max; $i++) {
             $this->saction_Draw($player_id, false);
         }
-        $this->notifyWithName('playerLog', clienttranslate('${player_name} draws ${x} card(s) up to their hand limit of ${max}'), [ 
-                'max' => $max,'player_id' => $player_id,'x' => ($max - $count) ]);
+        $this->notifyWithName('playerLog', clienttranslate('${player_name} draws ${x} card(s) up to their hand limit of ${max}'), [
+            'max' => $max, 'player_id' => $player_id, 'x' => ($max - $count)
+        ]);
         $this->notifyCounter("deck_$color");
         $this->notifyCounter("discard_$color");
         $this->notifyCounter("hand_$color");
     }
 
-    function saction_Draw($player_id, $useNotif = true) {
+    function saction_Draw($player_id, $useNotif = true)
+    {
         // draw 1 card
         $color = $this->getPlayerColor($player_id);
         $picked_arr = $this->tokens->pickTokensForLocation(1, "deck_$color", "hand_$color");
@@ -1513,8 +1590,10 @@ class EminentDomain extends EuroGame {
             $notif = '';
             if ($useNotif)
                 $notif = clienttranslate('${you} draw ${token_name}');
-            $this->dbSetTokenLocation($picked ['key'], "hand_$color", 1, $notif, [ '_private' => true,
-                    'player_id' => $player_id,'you' => 'you' ]);
+            $this->dbSetTokenLocation($picked['key'], "hand_$color", 1, $notif, [
+                '_private' => true,
+                'player_id' => $player_id, 'you' => 'you'
+            ]);
             //clienttranslate('${you} draw ${token_name}')
         }
         if ($useNotif) {
@@ -1524,22 +1603,23 @@ class EminentDomain extends EuroGame {
         }
     }
 
-    function saction_Role($leader, $role, $card, $color, $boost, $choices) {
+    function saction_Role($leader, $role, $card, $color, $boost, $choices)
+    {
         //throw new BgaUserException($color);
         $player_id = $this->getPlayerIdByColor($color);
         //$this->warn("plays Role leader=$leader role=$role card=$card boost=/$boost/ /$choices/");
         $choices_arr = $choices;
         $boost = trim($boost);
-        $boost_arr = $boost ? explode(' ', $boost) : [ ];
+        $boost_arr = $boost ? explode(' ', $boost) : [];
         // can be leader
         $bureacracy = $this->playerHasCard('card_tech_3_97', $color);
-        if ( !$leader && $bureacracy && ($role == 'C' || $role == 'W'))
+        if (!$leader && $bureacracy && ($role == 'C' || $role == 'W'))
             $leader = true;
-        
+
         // role notify and follower
-        $role_name = $this->materials ['icons'] [$role];
-        $role_args = [ 'player_id' => $player_id,'role_name' => $role_name,'i18n' => [ 'role_name' ] ];
-        
+        $role_name = $this->materials['icons'][$role];
+        $role_args = ['player_id' => $player_id, 'role_name' => $role_name, 'i18n' => ['role_name']];
+
         if (startsWith($card, "x_follow")) {
             $follower = true;
             $this->notifyWithName('playerLog', clienttranslate('${player_name} follows ${role_name} role'), $role_args);
@@ -1561,28 +1641,31 @@ class EminentDomain extends EuroGame {
             $freedome = $this->playerHasCard('card_tech_E_2', $color);
             if ($freedome) {
                 if (count($choices_arr) > 0) {
-                    $lookup = strtoupper($choices_arr [0] [0]);
+                    $lookup = strtoupper($choices_arr[0][0]);
                     if ($lookup != $role) {
                         $role = $lookup; // role changed
                         $notif = clienttranslate('${player_name} activates triggered effects of ${token_name}');
-                        $this->notifyWithName('playerLog', $notif, [ 'player_id' => $player_id,'token_id' => $freedome,
-                                'token_name' => $freedome ]);
+                        $this->notifyWithName('playerLog', $notif, [
+                            'player_id' => $player_id, 'token_id' => $freedome,
+                            'token_name' => $freedome
+                        ]);
                     }
                 }
             }
         }
-            
-        $iconsinfo = $this->arg_iconsInfo($color, [ $role ], $event);
-        $perm_boost = $iconsinfo ['perm_boost_num'] [$role];
+
+        $iconsinfo = $this->arg_iconsInfo($color, [$role], $event);
+        $perm_boost = $iconsinfo['perm_boost_num'][$role];
         $hand_boost = 0;
-        foreach ( $boost_arr as $boost_card ) {
-            $this->systemAssertTrue("card $boost_card has no boost $role", array_key_exists($boost_card, $iconsinfo ['hand_boost'] [$role]));
-            $hand_boost += $iconsinfo ['hand_boost'] [$role] [$boost_card];
+        foreach ($boost_arr as $boost_card) {
+            $this->systemAssertTrue("card $boost_card has no boost $role", array_key_exists($boost_card, $iconsinfo['hand_boost'][$role]));
+            $hand_boost += $iconsinfo['hand_boost'][$role][$boost_card];
         }
 
-        if ( !startsWith($card, "x_")) {
-            $this->notifyWithName('playerLog', clienttranslate('${player_name} gains ${token_name} role card'), [ 
-                    'token_name' => $card ]);
+        if (!startsWith($card, "x_")) {
+            $this->notifyWithName('playerLog', clienttranslate('${player_name} gains ${token_name} role card'), [
+                'token_name' => $card
+            ]);
             array_unshift($boost_arr, $card);
             $hand_boost++;
         } else if (getPart($card, 2, true) === "bottom") {
@@ -1591,7 +1674,7 @@ class EminentDomain extends EuroGame {
         $strength = $hand_boost + $perm_boost;
 
 
-        if ( !$leader && $strength == 0 && $role != 'R') {
+        if (!$leader && $strength == 0 && $role != 'R') {
             //$this->userAssertTrue(self::_("To follow this Role add boost or choose Dissent"));
             $this->notifyWithName('playerLog', clienttranslate('${player_name} has no boost for this role'), $role_args);
             return;
@@ -1601,14 +1684,14 @@ class EminentDomain extends EuroGame {
         // $this->warn("$role with ".toJson($boost_arr));
         $thor_sur = null;
         switch ($role) {
-            case 'C' : // Colonize
+            case 'C': // Colonize
                 $this->setGameStateValue('role', 3);
-                while ( count($choices_arr) > 0 ) {
+                while (count($choices_arr) > 0) {
                     $params = array_shift($choices_arr);
                     $command = array_shift($params);
 
                     if ($command === 'c') {
-                        $planet = $params [0];
+                        $planet = $params[0];
                         $bcard = array_shift($boost_arr);
                         if ($bcard && !startsWith($bcard, "x_"))
                             $this->saction_Colonize($bcard, $color, $planet);
@@ -1617,12 +1700,12 @@ class EminentDomain extends EuroGame {
                     } else if ($command === 's') {
                         $this->systemAssertTrue("Cannot settle the planet if not a role leader", $leader);
                         $bcard = array_shift($boost_arr);
-                        $planet = $params [0];
+                        $planet = $params[0];
                         if ($this->saction_Settle($bcard, $color, $planet, $choices_arr) == false) {
                             $this->userAssertTrue(self::_("Planet does not have enough colonies"));
                         }
                         if ($bcard &&  !startsWith($bcard, "x_")) {
-                            $this->saction_PlayCardsToAside($player_id, [ $bcard ], '');
+                            $this->saction_PlayCardsToAside($player_id, [$bcard], '');
                         }
                     } else if ($command === 'x') {
                         // do nothing
@@ -1632,9 +1715,9 @@ class EminentDomain extends EuroGame {
                 }
                 // anything left
                 $this->saction_PlayCardsToAside($player_id, $boost_arr, clienttranslate('${player_name} plays boost ${token_names}'));
-                $this->notifyCounter("supply_colonize", [ 'noa' => true ]);
+                $this->notifyCounter("supply_colonize", ['noa' => true]);
                 break;
-            case 'W' : // Warfare
+            case 'W': // Warfare
                 $this->setGameStateValue('role', 0);
                 if (count($choices_arr) > 0) {
                     $params = array_shift($choices_arr);
@@ -1650,22 +1733,23 @@ class EminentDomain extends EuroGame {
                 } else {
                     $collect = $this->dbGetFreeFighterInfo('F', $strength, true);
                     //$this->warn("collect fighters $strength ".toJson($collect));
-                    $this->dbSetTokensLocation($collect, "tableau_$color", 0, clienttranslate('${player_name} collects ${token_div_count}'), [ 
-                            'player_id' => $player_id ]);
+                    $this->dbSetTokensLocation($collect, "tableau_$color", 0, clienttranslate('${player_name} collects ${token_div_count}'), [
+                        'player_id' => $player_id
+                    ]);
                 }
-                $this->notifyCounter("supply_warfare", [ 'noa' => true ]);
+                $this->notifyCounter("supply_warfare", ['noa' => true]);
                 break;
-            case 'S' : // Survey
+            case 'S': // Survey
 
-                foreach ( $choices_arr as $i => $params ) {
-                    if ($params [0] === 'activate') {
-                        if ($params [1] === 'card_tech_E_24') { //thorough survey
-                            unset($choices_arr [$i]);
+                foreach ($choices_arr as $i => $params) {
+                    if ($params[0] === 'activate') {
+                        if ($params[1] === 'card_tech_E_24') { //thorough survey
+                            unset($choices_arr[$i]);
                             $thor_sur = 'card_tech_E_24';
                         }
                     }
                 }
-                
+
                 $this->setGameStateValue('role', 1);
                 $lookup = $strength - 1;
                 if ($leader)
@@ -1683,26 +1767,30 @@ class EminentDomain extends EuroGame {
                 $place_id = "supply_planets";
                 $picked_arr = $this->tokens->pickTokensForLocation($lookup, $place_id, "hand_$color");
                 $count = count($picked_arr);
-               // $this->warn("survey $thor_sur lookup=$lookup f=$follower count=$count|");
+                // $this->warn("survey $thor_sur lookup=$lookup f=$follower count=$count|");
                 if ($count) {
                     if ($count == 1) {
                         // right into tableu no choosing since only one
                         $token_id = $picked_arr[0]['key'];
-                        $this->dbSetTokenLocation($token_id, "tableau_$color", 0, clienttranslate('${player_name} draws a planet, its picked automatically since its the only one'), [ 
-                                'player_id' => $player_id ]);
+                        $this->dbSetTokenLocation($token_id, "tableau_$color", 0, clienttranslate('${player_name} draws a planet, its picked automatically since its the only one'), [
+                            'player_id' => $player_id
+                        ]);
                     } else {
-                        $this->dbSetTokensLocation($picked_arr, "hand_$color", 0, clienttranslate('${player_name} draws ${count} planets'), [ 
-                                'player_id' => $player_id,'count' => $count ]);
-                        $this->dbSetTokensLocation($picked_arr, "hand_$color", 1, '', [ 'player_id' => $player_id,
-                                '_private' => true]);
+                        $this->dbSetTokensLocation($picked_arr, "hand_$color", 0, clienttranslate('${player_name} draws ${count} planets'), [
+                            'player_id' => $player_id, 'count' => $count
+                        ]);
+                        $this->dbSetTokensLocation($picked_arr, "hand_$color", 1, '', [
+                            'player_id' => $player_id,
+                            '_private' => true
+                        ]);
                     }
                     if ($thor_sur && $count == 2) {
                         $this->notifyAnimate();
-                        $this->dbSetTokensLocation($picked_arr, "tableau_$color", 0, clienttranslate('${player_name} picks 2 planets'), [ 'player_id' => $player_id ]);
+                        $this->dbSetTokensLocation($picked_arr, "tableau_$color", 0, clienttranslate('${player_name} picks 2 planets'), ['player_id' => $player_id]);
                     }
                     $this->revealPlanetSupplyTop();
                 } else {
-                    if ( !$leader)
+                    if (!$leader)
                         $this->userAssertTrue(self::_("No more planets left"));
                 }
                 if ($thor_sur && $count > 2) {
@@ -1711,18 +1799,18 @@ class EminentDomain extends EuroGame {
                 } else {
                     $thor_sur = null;
                 }
-                $this->notifyCounter("supply_survey", [ 'noa' => true ]);
+                $this->notifyCounter("supply_survey", ['noa' => true]);
                 break;
-            case 'P' :
-            case 'T' :
-                if (!$follower) 
+            case 'P':
+            case 'T':
+                if (!$follower)
                     $this->setGameStateValue('role', ($role == 'P') ? 4 : 5);
                 $rule = ($role == 'P') ? 'p' : 't';
                 $rules = str_repeat($rule, $strength);
                 $this->saction_ExecuteRules("x_auto", $color, $choices_arr, $rules, false);
-                $this->notifyCounter("supply_produce", [ 'noa' => true ]);
+                $this->notifyCounter("supply_produce", ['noa' => true]);
                 break;
-            case 'R' : // Research
+            case 'R': // Research
                 $this->setGameStateValue('role', 2);
                 $this->systemAssertTrue("Bad research command - no args", count($choices_arr) >= 1);
                 $choice = array_shift($choices_arr);
@@ -1732,14 +1820,14 @@ class EminentDomain extends EuroGame {
                     break; // skipping tech
                 }
 
-                $tech = $params [0];
+                $tech = $params[0];
                 if (startsWith($tech, 'card_fleet_b'))
                     $tech = preg_replace("/_b_/", "_i_", $tech);
                 if ($this->saction_PayForTech($tech, $color, $strength, $choices_arr))
                     $this->saction_BuyTech($tech, $color, $role_args);
-                $this->notifyCounter("supply_research", [ 'noa' => true ]);
+                $this->notifyCounter("supply_research", ['noa' => true]);
                 break;
-            default :
+            default:
                 $this->userAssertTrue("Not implemented yet");
                 break;
         }
@@ -1749,44 +1837,47 @@ class EminentDomain extends EuroGame {
             $this->pushAbility($color, $thor_sur, null, CARD_RULE_SPECIAL);
     }
 
-    function saction_PayForTech($tech, $color, $strength, &$choices_arr) {
+    function saction_PayForTech($tech, $color, $strength, &$choices_arr)
+    {
         $techs = $this->arg_research($color, $tech, true);
-        if ( !isset($techs [$tech])) {
+        if (!isset($techs[$tech])) {
             $this->userAssertTrue(self::_("Not enough colonized planets to research this Technology"), true);
         }
-        $rec = $techs [$tech];
-        $cost = $rec ['b'];
+        $rec = $techs[$tech];
+        $cost = $rec['b'];
         $rem = $this->getGameStateValue('boost_rem');
         if ($rem > 0)
             $strength = $rem;
         $this->systemAssertTrue('missing payment info', $choices_arr && count($choices_arr) > 0);
-        $payment1 = $choices_arr [0];
-        if ($payment1 [0] == 'R') {
+        $payment1 = $choices_arr[0];
+        if ($payment1[0] == 'R') {
             if ($strength >= $cost) {
                 //$hand_boost + $perm_boost;
                 $this->setGameStateValue('boost_rem', $strength - $cost);
                 $mcost = $cost;
-                while ( count($choices_arr) > 0 && $mcost > 0 ) {
+                while (count($choices_arr) > 0 && $mcost > 0) {
                     array_shift($choices_arr);
                     $mcost--;
                 }
                 // use research
             } else {
-                $this->notifyWithName('playerLog', 
-                        clienttranslate('${player_name} does not have enough boost to buy ${token_name}'),
-                        ['token_id'=>$tech, 'token_name'=>$tech]);
+                $this->notifyWithName(
+                    'playerLog',
+                    clienttranslate('${player_name} does not have enough boost to buy ${token_name}'),
+                    ['token_id' => $tech, 'token_name' => $tech]
+                );
                 if ($rem > 0)
                     $mess = sprintf(self::_("This card %s requires %d research cost, remaining boost is %d"), self::_($tech), $cost, $strength);
                 else
-                    $mess = sprintf(self::_("This card %s requires %d research cost, boost of %d was provided"),self::_($tech), $cost, $strength);
+                    $mess = sprintf(self::_("This card %s requires %d research cost, boost of %d was provided"), self::_($tech), $cost, $strength);
                 $this->userAssertTrue($mess);
                 return false;
             }
         } else {
-            if ($rec ['canattack']) {
+            if ($rec['canattack']) {
                 // use attack
-                $ftype = $rec ['bm'] [1];
-                $mcost = $rec ['bm'] [0];
+                $ftype = $rec['bm'][1];
+                $mcost = $rec['bm'][0];
                 $rules = str_repeat($ftype, $mcost) . ">";
                 $this->saction_ExecuteRules("x_auto", $color, $choices_arr, $rules, false);
             } else {
@@ -1798,27 +1889,28 @@ class EminentDomain extends EuroGame {
         $sm = $this->playerHasCard('card_tech_E_9', $color, false);
         if ($sm) { // scientific method untapped
             // MARK used planets and perm boost
-            $mark_planets = $rec ['pl'];
-            foreach ( $mark_planets as $planet ) {
+            $mark_planets = $rec['pl'];
+            foreach ($mark_planets as $planet) {
                 $this->dbSetTokenState($planet, CARD_STATE_PLANET_USED_AS_REQ);
             }
         }
         return true;
     }
 
-    function saction_BuyTech($tech, $color = null, $extra_args = null) {
+    function saction_BuyTech($tech, $color = null, $extra_args = null)
+    {
         if ($color === null) {
             $player_id = $this->getActivePlayerId();
             $color = $this->getPlayerColorById($player_id);
         } else
             $player_id = $this->getPlayerIdByColor($color);
-        if ( !$extra_args) {
-            $extra_args = [ 'player_id' => $player_id];
+        if (!$extra_args) {
+            $extra_args = ['player_id' => $player_id];
         }
         if (startsWith($tech, 'card_fleet_i')) {
             $ownfleet = $this->tokens->getTokenOfTypeInLocation('card_fleet', "tableau_${color}");
             $this->dbSetTokenLocation($tech, "tableau_$color", 1, clienttranslate('${player_name} researches ${token_name} Technology'), $extra_args);
-            $this->dbSetTokenLocation($ownfleet ['key'], "dev_null", 0, '');
+            $this->dbSetTokenLocation($ownfleet['key'], "dev_null", 0, '');
             return;
         }
         $location = $this->tokens->getTokenLocation($tech);
@@ -1829,58 +1921,67 @@ class EminentDomain extends EuroGame {
             $flip = $this->getRulesFor($tech, 'flip');
             $this->dbSetTokenLocation($flip, "dev_null", 0, '');
             if ($inf > 0)
-                $this->dbIncScoreValueAndNotify($player_id, $inf, clienttranslate('${player_name} gains +${inc} Influence from card ${token_name}'), 'game_cards', [ 
-                        'token_id' => $tech,'token_name' => $tech,'place' => $tech ]);
+                $this->dbIncScoreValueAndNotify($player_id, $inf, clienttranslate('${player_name} gains +${inc} Influence from card ${token_name}'), 'game_cards', [
+                    'token_id' => $tech, 'token_name' => $tech, 'place' => $tech
+                ]);
             // card come into play effects
             if ($tech === 'card_tech_3_87') { //Productivity
                 $this->incGameStateValue('actions_allowed', 1);
             }
             $this->saction_TriggerAbilities("enter", $color, $tech);
         } else {
-           // $this->dbSetTokenLocation($tech, "tableau_$color", 1, '');
+            // $this->dbSetTokenLocation($tech, "tableau_$color", 1, '');
             if ($inf > 0)
-                $this->dbIncScoreValueAndNotify($player_id, $inf, clienttranslate('${player_name} gains +${inc} Influence from card ${token_name}'), 'game_cards', [ 
-                        'token_id' => $tech,'token_name' => $tech,'place' => "tableau_$color" ]);
+                $this->dbIncScoreValueAndNotify($player_id, $inf, clienttranslate('${player_name} gains +${inc} Influence from card ${token_name}'), 'game_cards', [
+                    'token_id' => $tech, 'token_name' => $tech, 'place' => "tableau_$color"
+                ]);
             $this->dbSetTokenLocation($tech, "hand_$color", 0, clienttranslate('${player_name} researches ${token_name} Technology'), $extra_args);
         }
     }
 
-    function saction_Attack($color, $planet, &$choices_arr, $card = null) {
+    function saction_Attack($color, $planet, &$choices_arr, $card = null)
+    {
         $player_id = $this->getPlayerIdByColor($color);
         if ($planet === 'skip') {
-            $this->notifyWithName('playerLog', clienttranslate('${player_name} skips attack'), [ 
-                    'player_id' => $player_id ]);
+            $this->notifyWithName('playerLog', clienttranslate('${player_name} skips attack'), [
+                'player_id' => $player_id
+            ]);
             return;
         }
-        
+
 
         $annex = ($card === 'card_tech_E_36'); // the attack action was chosen by playing the annex card
-        
+
         $militaryCampaign = $this->playerHasCard('card_tech_E_38', $color);
- 
+
         //$this->warn("playing attack /$color/ /$planet/".toJson($choices_arr));
-        $info=$this->tokens->getTokenInfo($planet);
+        $info = $this->tokens->getTokenInfo($planet);
         $state = $info['state'];
-        $owner_color = getPart($info ['location'], 1);
-        $inc=$this->getRulesFor($planet,'v');
+        $owner_color = getPart($info['location'], 1);
+        $inc = $this->getRulesFor($planet, 'v');
         if ($state == 1 && $militaryCampaign) {
             $cost = 'B' . (str_repeat('F', $inc));
             $notif = clienttranslate('${player_name} activates effects of ${token_name}');
-            $this->notifyWithName('playerLog', $notif, [ 'player_id' => $player_id,'token_id' => $militaryCampaign,
-                    'token_name' => $militaryCampaign ]);
+            $this->notifyWithName('playerLog', $notif, [
+                'player_id' => $player_id, 'token_id' => $militaryCampaign,
+                'token_name' => $militaryCampaign
+            ]);
 
-      
-            $this->dbIncScoreValueAndNotify($this->getPlayerIdByColor($owner_color), -$inc, clienttranslate('${player_name} loses ${inc} Influence from ${place_name}'), 'game_planets', [ 
-                    'place_id' => $planet,'place_name' => $planet,'place' => $planet ]);
+
+            $this->dbIncScoreValueAndNotify($this->getPlayerIdByColor($owner_color), -$inc, clienttranslate('${player_name} loses ${inc} Influence from ${place_name}'), 'game_planets', [
+                'place_id' => $planet, 'place_name' => $planet, 'place' => $planet
+            ]);
             $this->notifyAnimate();
-            $this->dbSetTokenLocation($planet, "tableau_$color", 1, clienttranslate('${player_name} Attacks ${token_name}'), [ 
-                    'player_id' => $player_id ]);
+            $this->dbSetTokenLocation($planet, "tableau_$color", 1, clienttranslate('${player_name} Attacks ${token_name}'), [
+                'player_id' => $player_id
+            ]);
             $this->saction_ExecuteRules(null, $color, $choices_arr, $cost . ">", false);
-            $this->dbIncScoreValueAndNotify($player_id, $inc, clienttranslate('${player_name} gains +${inc} Influence from ${place_name}'), 'game_planets', [ 
-                    'place_id' => $planet,'place_name' => $planet,'place' => $planet ]);
-            
+            $this->dbIncScoreValueAndNotify($player_id, $inc, clienttranslate('${player_name} gains +${inc} Influence from ${place_name}'), 'game_planets', [
+                'place_id' => $planet, 'place_name' => $planet, 'place' => $planet
+            ]);
+
             $this->saction_Reparations($this->getPlayerIdByColor($owner_color), 2);
-            
+
             $scorchedEarthPolicy = false;
         } else {
             $this->systemAssertTrue("planet is already colonized", $state == 0);
@@ -1888,11 +1989,11 @@ class EminentDomain extends EuroGame {
             // warfare discounts
             $imp_fleet = $this->tokens->getTokenOfTypeInLocation("card_fleet_i", "tableau_$color");
             $scorchedEarthPolicy = $this->playerHasCard('card_tech_2_85', $color);
-            
+
             $mrec = $this->mtGetFightCost($planet);
-            $cost = $mrec ['rule'];
+            $cost = $mrec['rule'];
             if (count($choices_arr) > 0 && $imp_fleet) {
-                if ($choices_arr [0] [0] === 'B') {
+                if ($choices_arr[0][0] === 'B') {
                     $cost = 'B';
                 }
             }
@@ -1900,24 +2001,28 @@ class EminentDomain extends EuroGame {
             if ($fdiscount) {
                 $cost = preg_replace("/F/", "", $cost, $fdiscount);
             }
-            
+
             // dispose of cards on the planet (i.e. colonies)
             $ptokens = $this->tokens->getTokensInLocation($planet);
             $owner_id = $this->getPlayerIdByColor($owner_color);
-            foreach ( $ptokens as $key => $info ) {
-                $this->dbSetTokenLocation($key, "setaside_$owner_color", CARD_STATE_USED_CARD, '', [ 'nod' => true,
-                        'player_id' => $owner_id ]);
+            foreach ($ptokens as $key => $info) {
+                $this->dbSetTokenLocation($key, "setaside_$owner_color", CARD_STATE_USED_CARD, '', [
+                    'nod' => true,
+                    'player_id' => $owner_id
+                ]);
             }
 
             // attack and pay
             $this->dbSetTokenLocation($planet, "tableau_$color", 1, clienttranslate('${player_name} Attacks ${token_name}'), [
-                    'player_id' => $player_id ]);
+                'player_id' => $player_id
+            ]);
             $this->saction_ExecuteRules(null, $color, $choices_arr, $cost . ">", false);
-            
+
             // score
             $this->dbIncScoreValueAndNotify($player_id, $inc, clienttranslate('${player_name} gains +${inc} Influence from ${place_name}'), 'game_planets', [
-                    'place_id' => $planet,'place_name' => $planet,'place' => $planet ]);
-            
+                'place_id' => $planet, 'place_name' => $planet, 'place' => $planet
+            ]);
+
             // reparations
             if ($owner_color !== $color && $annex) {
                 $this->saction_Reparations($owner_id, 2);
@@ -1929,7 +2034,7 @@ class EminentDomain extends EuroGame {
         if ($scorchedEarthPolicy) {
             // Move 1 fighter on the card from the reserve
             $f1 = $this->dbGetFreeFighterInfo();
-            $this->dbSetTokenLocation($f1 ['key'], $planet, RESOURCE_STATE_BLOCKER, '', [ 'nod' => true ]);
+            $this->dbSetTokenLocation($f1['key'], $planet, RESOURCE_STATE_BLOCKER, '', ['nod' => true]);
         }
         // triggered
         $this->saction_TriggerAbilities("attack", $color, $planet);
@@ -1937,15 +2042,16 @@ class EminentDomain extends EuroGame {
         $this->notifyAnimate();
     }
 
-    function saction_TriggerAbilities($event, $color, $other) {
-            // cards with triggering ability
-            // test: saction_TriggerAbilities(enter,ff0000,card_tech_2_95)   
+    function saction_TriggerAbilities($event, $color, $other)
+    {
+        // cards with triggering ability
+        // test: saction_TriggerAbilities(enter,ff0000,card_tech_2_95)   
         if ($event === 'enter') { // replenish triggers on enter
             $this->saction_AutoReplenish($other, $color);
         }
         $cards = $this->mtTriggering($event);
         //$this->debugConsole("trig event [$event] $color $other ",$cards);
-        foreach ( $cards as $card ) {
+        foreach ($cards as $card) {
             if ($event === 'enter') { // enter events only trigger on itself
                 if ($other === $card) {
                     $forreal = $card;
@@ -1954,7 +2060,7 @@ class EminentDomain extends EuroGame {
                 }
             } else
                 $forreal = $this->playerHasCard($card, $color);
-      
+
             if ($forreal) {
                 //$this->debugConsole("trig check $card $event $other $forreal");
                 $triginfo = $this->mtTriggerInfo($card, $event);
@@ -1963,9 +2069,10 @@ class EminentDomain extends EuroGame {
         }
     }
 
-    function saction_AutoPerform($color, $card_id, $rules) {
-        if (count(array_count_values(str_split($rules))) == 1) {// all rules is the same command, i.e. iii or pp
-            $command = $rules [0];
+    function saction_AutoPerform($color, $card_id, $rules)
+    {
+        if (count(array_count_values(str_split($rules))) == 1) { // all rules is the same command, i.e. iii or pp
+            $command = $rules[0];
             $count = strlen($rules);
             if ($command == 'p') {
                 return $this->saction_ProduceBonus($card_id, $color, $count);
@@ -1979,29 +2086,34 @@ class EminentDomain extends EuroGame {
         return false;
     }
 
-    function saction_RemoveCardFromGame($card, $player_id, &$ret_owner_player_id = null) {
+    function saction_RemoveCardFromGame($card, $player_id, &$ret_owner_player_id = null)
+    {
         // If the removed card was worth some points, lose them
         $owner_color = $this->getCardOwnerColor($card);
         $owner_player_id = $this->getPlayerIdByColor($owner_color);
         if ($owner_player_id !== 0) {
             // move tokens off the card if any
             $tokens = $this->tokens->getTokensInLocation($card);
-            foreach ( $tokens as $key => $info ) {
-                $this->dbSetTokenLocation($key, "setaside_$owner_color", CARD_STATE_USED_CARD, '', [ 'nod' => true,
-                        'player_id' => $owner_player_id ]);
+            foreach ($tokens as $key => $info) {
+                $this->dbSetTokenLocation($key, "setaside_$owner_color", CARD_STATE_USED_CARD, '', [
+                    'nod' => true,
+                    'player_id' => $owner_player_id
+                ]);
             }
             $inf = $this->getRulesFor($card, 'v');
             //$this->warn("removing $card $owner_color $owner_player_id $inf");
             if ($inf > 0) {
-                $this->dbIncScoreValueAndNotify($owner_player_id, -$inf, clienttranslate('${player_name} loses ${inc} Influence from removing card ${token_name}'), 'game_cards', [ 
-                        'token_id' => $card,'token_name' => $card,'place' => $card ]);
+                $this->dbIncScoreValueAndNotify($owner_player_id, -$inf, clienttranslate('${player_name} loses ${inc} Influence from removing card ${token_name}'), 'game_cards', [
+                    'token_id' => $card, 'token_name' => $card, 'place' => $card
+                ]);
             }
         }
         $this->dbSetTokenLocation($card, "dev_null", 0, clienttranslate('${player_name} removes ${token_name} from the game'));
         $ret_owner_player_id = $owner_player_id;
     }
 
-    function saction_Settle($card, $color, $planet,&$choices_arr) {
+    function saction_Settle($card, $color, $planet, &$choices_arr)
+    {
         $cost = $this->getRulesFor($planet, 'c');
         if ($cost >= 99) {
             $this->userAssertTrue(self::_('Cannot colonize hostile planet'));
@@ -2015,12 +2127,12 @@ class EminentDomain extends EuroGame {
         $colship = $this->playerHasCard('card_tech_E_21', $color, true);
         if ($colship) {
             //$this->warn("colship $colship ".toJson($choices_arr));
-            while ( count($choices_arr) > 0 ) {
-                $command = $choices_arr [0] [0];
+            while (count($choices_arr) > 0) {
+                $command = $choices_arr[0][0];
                 if ($command == 'c') {
                     $params = array_shift($choices_arr);
-                    $colony = $params [2];
-                    $planet2 = $params [1];
+                    $colony = $params[2];
+                    $planet2 = $params[1];
                     $this->saction_Colonize($colony, $color, $planet2);
                 } else {
                     break;
@@ -2029,19 +2141,24 @@ class EminentDomain extends EuroGame {
         }
         if ($this->isReadyToBeSettled($planet, $perm_boost)) {
             if ($card === "x_follow") {
-                $this->notifyWithName('playerLog', clienttranslate('${player_name} follows Colonize ROLE: settle a planet'), [ 
-                        'player_id' => $player_id ]);
+                $this->notifyWithName('playerLog', clienttranslate('${player_name} follows Colonize ROLE: settle a planet'), [
+                    'player_id' => $player_id
+                ]);
             }
             $tokens = $this->tokens->getTokensInLocation($planet);
-            foreach ( $tokens as $key => $info ) {
-                $this->dbSetTokenLocation($key, "setaside_$color", CARD_STATE_USED_CARD, '', [ 'nod' => true,
-                        'player_id' => $player_id ]);
+            foreach ($tokens as $key => $info) {
+                $this->dbSetTokenLocation($key, "setaside_$color", CARD_STATE_USED_CARD, '', [
+                    'nod' => true,
+                    'player_id' => $player_id
+                ]);
             }
             $this->dbSetTokenLocation($planet, "tableau_$color", 1, clienttranslate('${player_name} settles ${token_name}'), [
-                    'player_id' => $player_id ]);
-            $inc = $this->token_types [$planet] ['v'];
-            $this->dbIncScoreValueAndNotify($player_id, $inc, clienttranslate('${player_name} gains +${inc} Influence from planet ${place_name}'), 'game_planets', [ 
-                    'place_id' => $planet,'place_name' => $planet,'place' => $planet ]);
+                'player_id' => $player_id
+            ]);
+            $inc = $this->token_types[$planet]['v'];
+            $this->dbIncScoreValueAndNotify($player_id, $inc, clienttranslate('${player_name} gains +${inc} Influence from planet ${place_name}'), 'game_planets', [
+                'place_id' => $planet, 'place_name' => $planet, 'place' => $planet
+            ]);
             // triggered
             $this->saction_TriggerAbilities("settle", $color, $planet);
             $this->saction_TriggerAbilities("enter", $color, $planet);
@@ -2051,7 +2168,8 @@ class EminentDomain extends EuroGame {
         }
     }
 
-    function saction_Colonize($card, $color, $planet) {
+    function saction_Colonize($card, $color, $planet)
+    {
 
         $cost = $this->getRulesFor($planet, 'c');
         if ($cost >= 99) {
@@ -2059,49 +2177,56 @@ class EminentDomain extends EuroGame {
         }
         $player_id = $this->getPlayerIdByColor($color);
         $sym = $this->getIconCount('C', $card, '*');
-        
+
         //$this->warn("colonize $card, $color, $planet");
-        $this->dbSetTokenLocation($card, $planet, RESOURCE_STATE_COLONIZE_BOOST, 
-                clienttranslate('${player_name} adds +${num} colony (card ${token_name}) to ${place_name}'), [ 
-                'player_id' => $player_id,'num' => $sym,
-                'log_others' => clienttranslate('${player_name} adds +${num} Colony (card ${token_name}) to an unknown planet') ]);
+        $this->dbSetTokenLocation(
+            $card,
+            $planet,
+            RESOURCE_STATE_COLONIZE_BOOST,
+            clienttranslate('${player_name} adds +${num} colony (card ${token_name}) to ${place_name}'),
+            [
+                'player_id' => $player_id, 'num' => $sym,
+                'log_others' => clienttranslate('${player_name} adds +${num} Colony (card ${token_name}) to an unknown planet')
+            ]
+        );
     }
 
-    function saction_Trade($card, $color, $planet, $token) {
+    function saction_Trade($card, $color, $planet, $token)
+    {
         $player_id = $this->getPlayerIdByColor($color);
         $this->systemAssertTrue("invalid param 1", $planet);
         $this->systemAssertTrue("invalid param 2", $token);
         $weaponEmporium = $this->playerHasCard('card_tech_2_74', $color);
         $diverseMarkets = $this->playerHasCard('card_tech_2_71', $color);
         $specialization = $this->playerHasCard('card_tech_2_73', $color);
-        
+
         $info = $this->tokens->getTokenInfo($token);
-        if ($info ['state'] == RESOURCE_STATE_COLONIZE_BOOST || $info ['state'] == RESOURCE_STATE_MARKER) {
+        if ($info['state'] == RESOURCE_STATE_COLONIZE_BOOST || $info['state'] == RESOURCE_STATE_MARKER) {
             // this is used as boost not to be traded
             $this->userAssertTrue(self::_("Cannot trade this resource, it is used as marker or boost"));
         }
         $restype = '';
         if (startsWith($token, 'fighter')) {
-            $is_f = startsWith($token, 'fighter_F') || startsWith($token, 'fighter_j'); 
+            $is_f = startsWith($token, 'fighter_F') || startsWith($token, 'fighter_j');
             $this->userAssertTrue(_('Can only trade Fighters with Weapon Emporium'),  $is_f && $weaponEmporium);
-            $this->dbSetTokenLocation($token, "stock_fighter", 0, clienttranslate('${player_name} trades ${token_name}'), [ 
-                    'player_id' => $player_id ]);
+            $this->dbSetTokenLocation($token, "stock_fighter", 0, clienttranslate('${player_name} trades ${token_name}'), [
+                'player_id' => $player_id
+            ]);
         } else if (startsWith($planet, 'card_tech') && $token == 'x') {
             // resource boost
-            $this->saction_PlayCardsToDiscard($player_id, [ $planet ], clienttranslate('${player_name} trades ${token_name} as resource'));
+            $this->saction_PlayCardsToDiscard($player_id, [$planet], clienttranslate('${player_name} trades ${token_name} as resource'));
             $restype = $this->getRulesFor($planet, 'asr');
-    
         } else {
-            $this->systemAssertTrue("bad parent $token", $info ['location'] == $planet);
-            $this->dbSetTokenLocation($token, 'stock_resource', 0, clienttranslate('${player_name} trades ${token_name}'), [ 
-                    'player_id' => $player_id ]);
+            $this->systemAssertTrue("bad parent $token", $info['location'] == $planet);
+            $this->dbSetTokenLocation($token, 'stock_resource', 0, clienttranslate('${player_name} trades ${token_name}'), [
+                'player_id' => $player_id
+            ]);
             $restype = getPart($token, 1);
-
         }
         if ($specialization) {
             $place = $specialization;
             $resource = $this->tokens->getTokenOnLocation($place);
-            $resourceType = getPart($resource ['key'], 1);
+            $resourceType = getPart($resource['key'], 1);
             if ($restype == $resourceType || $restype === 'n') {
                 $this->saction_GainInfluenceTokens($player_id, 1, $place);
             }
@@ -2110,14 +2235,15 @@ class EminentDomain extends EuroGame {
             // summon resource counter
             if ($restype) { // can be fighter
                 $resourceInfo = $this->dbGetFreeResourceInfo($restype);
-                $this->dbSetTokensLocation([ $resourceInfo ], $diverseMarkets, RESOURCE_STATE_MARKER, '');
+                $this->dbSetTokensLocation([$resourceInfo], $diverseMarkets, RESOURCE_STATE_MARKER, '');
             }
         }
-        
+
         $this->saction_GainInfluenceTokens($player_id, 1, $planet);
     }
 
-    function saction_Produce($card, $color, $planet, $restype, $resid) {
+    function saction_Produce($card, $color, $planet, $restype, $resid)
+    {
         if ($planet == 'x_random') {
             $this->saction_ProduceRandom($color);
             return;
@@ -2127,14 +2253,14 @@ class EminentDomain extends EuroGame {
         $this->systemAssertTrue("invalid param 2", $restype);
         if ($resid === 'x') {
             $resourceInfo = $this->dbGetFreeResourceInfo($restype);
-            $token = $resourceInfo ['key'];
+            $token = $resourceInfo['key'];
         } else {
             $token = $resid;
             $restype = getPart($token, 1);
             $loc = $this->tokens->getTokenLocation($resid);
             if ($loc !== 'stock_resource') {
                 $resourceInfo = $this->dbGetFreeResourceInfo($restype);
-                $token = $resourceInfo ['key'];
+                $token = $resourceInfo['key'];
             }
             //$this->systemAssertTrue("invalid resource token $resid $loc", $loc === 'stock_resource');
         }
@@ -2142,25 +2268,25 @@ class EminentDomain extends EuroGame {
         $info = array_value_get($planets, $planet);
         $this->systemAssertTrue("planet has not resource slots '$planet' " . toJson($planets, null), $info);
         //$this->warn("producing on $planet for $restype $resid $token ".toJson($info));
-        $this->systemAssertTrue("No more free slots on this planet $planet for $restype $resid $token " . toJson($info), array_value_get($info ['resf'], $restype) > 0 || array_value_get($info ['resf'], 'n') > 0);
-        $this->userAssertTrue(clienttranslate("No more free slots on this planet"), array_value_get($info ['resf'], $restype) > 0 || array_value_get($info ['resf'], 'n') > 0);
-        $this->dbSetTokenLocation($token, $planet, RESOURCE_STATE_PRODUCE, clienttranslate('${player_name} produces ${token_name} on ${place_name}'), [ 
-                'player_id' => $player_id ]);
+        $this->systemAssertTrue("No more free slots on this planet $planet for $restype $resid $token " . toJson($info), array_value_get($info['resf'], $restype) > 0 || array_value_get($info['resf'], 'n') > 0);
+        $this->userAssertTrue(clienttranslate("No more free slots on this planet"), array_value_get($info['resf'], $restype) > 0 || array_value_get($info['resf'], 'n') > 0);
+        $this->dbSetTokenLocation($token, $planet, RESOURCE_STATE_PRODUCE, clienttranslate('${player_name} produces ${token_name} on ${place_name}'), [
+            'player_id' => $player_id
+        ]);
         // Genetic Engineering & Specialized Production
         // add resource marker
         $geneticEngineering = $this->playerHasCard('card_tech_2_92', $color);
         if ($geneticEngineering)
-            $this->dbSetTokensLocation([ $this->dbGetFreeResourceInfo($restype) ], $geneticEngineering, RESOURCE_STATE_MARKER, '');
+            $this->dbSetTokensLocation([$this->dbGetFreeResourceInfo($restype)], $geneticEngineering, RESOURCE_STATE_MARKER, '');
         $specProd = $this->playerHasCard('card_tech_E_18', $color);
         if ($specProd) {
             $place = $specProd;
             $resource = $this->tokens->getTokenOnLocation($place);
-            $resourceTypeSelected = getPart($resource ['key'], 1);
-            if ($restype == $resourceTypeSelected ) {
+            $resourceTypeSelected = getPart($resource['key'], 1);
+            if ($restype == $resourceTypeSelected) {
                 $this->saction_GainInfluenceTokens($player_id, 1, $place);
             }
         }
-        
     }
 
     /**
@@ -2170,13 +2296,14 @@ class EminentDomain extends EuroGame {
      * @param string $color
      * @param number $max
      */
-    function saction_ProduceBonus($card, $color, $max) {
+    function saction_ProduceBonus($card, $color, $max)
+    {
         $planets = $this->arg_holders($color);
         $count = 0;
         $hasany = false;
-        foreach ( $planets as $planet => $info ) {
-            $freeresslots = $info ['resf'];
-            foreach ( $freeresslots as $c => $v ) {
+        foreach ($planets as $planet => $info) {
+            $freeresslots = $info['resf'];
+            foreach ($freeresslots as $c => $v) {
                 if ($v > 0) {
                     $count += $v;
                     if ($c == 'n') // cannot auto-produce on Any
@@ -2190,7 +2317,7 @@ class EminentDomain extends EuroGame {
         $count = 0;
         // produce on  random planets
         $produced = true;
-        while ( $count < $max && $produced ) {
+        while ($count < $max && $produced) {
             $produced = $this->saction_ProduceRandom($color);
             if ($produced) {
                 $count++;
@@ -2199,34 +2326,36 @@ class EminentDomain extends EuroGame {
         return true;
     }
 
-    function saction_ProduceRandom($color) {
+    function saction_ProduceRandom($color)
+    {
         $planets = $this->arg_holders($color);
         shuffle_assoc($planets);
-            //$this->systemAssertTrue(print_r($planets, true));
-        $allres = [ 'w','f','s','i' ];
-        foreach ( $planets as $planet => $info ) {
-            $freeresslots = $info ['resf'];
-            $restypes = [ ];
-            foreach ( $freeresslots as $c => $v ) {
+        //$this->systemAssertTrue(print_r($planets, true));
+        $allres = ['w', 'f', 's', 'i'];
+        foreach ($planets as $planet => $info) {
+            $freeresslots = $info['resf'];
+            $restypes = [];
+            foreach ($freeresslots as $c => $v) {
                 if ($v > 0) {
                     if ($c != 'n')
-                        $restypes [] = $c;
+                        $restypes[] = $c;
                     else {
                         shuffle($allres);
-                        $restypes [] = $allres [0];
+                        $restypes[] = $allres[0];
                     }
                 }
             }
             if (count($restypes) > 0) {
                 shuffle($restypes);
-                $this->saction_Produce('x', $color, $planet, $restypes [0], 'x');
+                $this->saction_Produce('x', $color, $planet, $restypes[0], 'x');
                 return true;
             }
         }
         return false;
     }
 
-    function saction_Action($card, $color, &$choices, $actnum = 0) {
+    function saction_Action($card, $color, &$choices, $actnum = 0)
+    {
         $this->systemAssertTrue("bad args no choices", is_array($choices));
         $player_id = $this->getPlayerIdByColor($color);
         $rules = $this->getRulesFor($card, 'a');
@@ -2234,8 +2363,10 @@ class EminentDomain extends EuroGame {
         $card_state = $this->tokens->getTokenState($card);
         $this->systemAssertTrue("$card is not in play", $card_state !== null);
         $notif = clienttranslate('${player_name} plays action of ${token_name}');
-        $this->notifyWithName('playerLog', $notif, [ 'player_id' => $player_id,'token_id' => $card,
-                'token_name' => $card, ]);
+        $this->notifyWithName('playerLog', $notif, [
+            'player_id' => $player_id, 'token_id' => $card,
+            'token_name' => $card,
+        ]);
         $partial = (strstr($rules, ".") !== false);
         if ($partial) {
             $rules2 = $this->getRulesByNum($card, CARD_RULE_ACTION_PART2);
@@ -2243,7 +2374,7 @@ class EminentDomain extends EuroGame {
                 $rules = $rules2;
             }
         }
-        
+
         $disposable = true;
         if ($this->isPermanentTech($card))
             $disposable = false;
@@ -2258,7 +2389,7 @@ class EminentDomain extends EuroGame {
                 if ($rules2 && $card_state != CARD_STATE_PARTIAL_ACTION)
                     $state = CARD_STATE_PARTIAL_ACTION; // partial play
             }
-            $this->saction_PlayCardsToAside($player_id, [ $card ], '', $state);
+            $this->saction_PlayCardsToAside($player_id, [$card], '', $state);
         } else {
             $state = CARD_STATE_PERMANENT;
             if ($partial) {
@@ -2276,7 +2407,7 @@ class EminentDomain extends EuroGame {
         }
         if ($card === 'card_tech_2_93') { // terraforming
             $params = array_shift($choices);
-            $planet = $params [1];
+            $planet = $params[1];
             $this->saction_Colonize($card, $color, $planet);
             $this->saction_Settle($card, $color, $planet, $choices);
             return;
@@ -2286,10 +2417,11 @@ class EminentDomain extends EuroGame {
         $this->saction_ValidateRestOfChoices($choices, $rules);
     }
 
-    
-    
 
-    function saction_ExecuteRules($card, $color, &$choices_arr, $rules, $action) {
+
+
+    function saction_ExecuteRules($card, $color, &$choices_arr, $rules, $action)
+    {
         if ($card === null)
             $card = "x_auto";
         //    $this->warn("rules $card $color $rules, $action".toJson($choices_arr));
@@ -2301,125 +2433,126 @@ class EminentDomain extends EuroGame {
         }
         $orig_rules = $rules;
         $i = 0;
-        $accomulator = [ ];
-        while ( count($choices_arr) > 0 && $rules ) {
+        $accomulator = [];
+        while (count($choices_arr) > 0 && $rules) {
             $params = array_shift($choices_arr);
-            if ( !is_array($params))
+            if (!is_array($params))
                 $this->systemAssertTrue("bad operation not array $params");
             $command = array_shift($params);
             $lookup = '';
             if (count($choices_arr) > 0) {
-                $lookup = $choices_arr [0] [0];
+                $lookup = $choices_arr[0][0];
             }
             $consume = $command;
             $replace = "";
             if (startsWith($rules, "%")) {
-                $what = $rules [1];
-                $to = $rules [2];
+                $what = $rules[1];
+                $to = $rules[2];
                 $finfo = $this->dbGetOwnFighterInfo($color, false);
-                $num = count($finfo [$what]);
+                $num = count($finfo[$what]);
                 $rules = str_repeat($to, $num) . substr($rules, 3);
             }
-           // $this->warn("command $command ".toJson($params, null));
+            // $this->warn("command $command ".toJson($params, null));
             switch ($command) {
-                case 'z' :
+                case 'z':
                     $pay = false;
                     $consume = ">";
                     break;
-                case 'Z' :      
+                case 'Z':
                     $pay = true;
                     $consume = "+";
                     $replace = $orig_rules;
                     break;
-                case 'd' : // draw a card
+                case 'd': // draw a card
                     $this->saction_Draw($player_id);
                     break;
-                case 'u' : // draw a planet
+                case 'u': // draw a planet
                     $place_id = "supply_planets"; //getTokensOnTop
                     $picked_arr = $this->tokens->pickTokensForLocation(1, $place_id, "hand_$color");
                     $count = count($picked_arr);
                     if ($count) {
                         $picked = array_shift($picked_arr);
-                        $token_id = $picked ['key'];
+                        $token_id = $picked['key'];
                         $this->dbSetTokenLocation($token_id, "tableau_$color", 0, clienttranslate('${player_name} draws a planet'));
                         $this->revealPlanetSupplyTop();
                     } else {
                         $this->userAssertTrue(self::_("No more planets left"));
                     }
                     break;
-                case 'l' : // polictics or AI
+                case 'l': // polictics or AI
                     if (startsWith($card, 'card_role_politics')) {
                         $this->saction_RemoveCardFromGame($card, $player_id);
                     }
-                    $role_card = $params [0];
+                    $role_card = $params[0];
                     $this->dbSetTokenLocation($role_card, "hand_$color", 0, clienttranslate('${player_name} gains ${token_name} into hand'));
                     break;
-                case 'e' : // remove
-                    $arg_card = $params [0];
+                case 'e': // remove
+                    $arg_card = $params[0];
                     $this->saction_RemoveCardFromGame($arg_card, $player_id);
                     break;
-                case 'E' :
-                    $arg_card = $params [0];
+                case 'E':
+                    $arg_card = $params[0];
                     $this->saction_RemoveCardFromGame($arg_card, $player_id);
                     if ($lookup === 'E') {
                         $consume = '';
                     }
                     break;
-                case 's' :
-                    $planet = $params [0];
-                    if ($this->saction_Settle($card, $color, $planet,$choices_arr) == false) {
+                case 's':
+                    $planet = $params[0];
+                    if ($this->saction_Settle($card, $color, $planet, $choices_arr) == false) {
                         $command = 'c';
                         $colony = $card;
                         $this->saction_Colonize($colony, $color, $planet);
                     }
                     break;
-                case 'S' :
-                    $planet = $params [0];
+                case 'S':
+                    $planet = $params[0];
                     if ($planet === 'skip')
                         break;
                     if ($this->saction_Settle($card, $color, $planet, $choices_arr) == false) {
                         $this->userAssertTrue(self::_("Planet does not have enough colonies"));
                     }
                     break;
-                case 'c' :
-                    $planet = $params [0];
-                    $colony = $params [1];
+                case 'c':
+                    $planet = $params[0];
+                    $colony = $params[1];
                     $this->saction_Colonize($colony, $color, $planet);
-                    if ($rules [0] == 's')
+                    if ($rules[0] == 's')
                         $consume = 's';
                     break;
-                case 'a' :
+                case 'a':
                     $planet = array_shift($params);
                     $this->saction_Attack($color, $planet, $choices_arr, $card);
                     break;
-                case 'p' : // produce
+                case 'p': // produce
                     $this->systemAssertTrue("invalid params " . count($params), count($params) == 3);
-                    $this->saction_Produce($card, $color, $params [0], $params [1], $params [2]);
+                    $this->saction_Produce($card, $color, $params[0], $params[1], $params[2]);
                     break;
-                case 't' : // trade
+                case 't': // trade
                     $this->systemAssertTrue("invalid params " . count($params), count($params) == 2);
-                    $this->saction_Trade($card, $color, $params [0], $params [1]);
+                    $this->saction_Trade($card, $color, $params[0], $params[1]);
                     break;
-                case 'F' :
-                case 'D' :
-                case 'B' :
+                case 'F':
+                case 'D':
+                case 'B':
                     if ($pay) {
-                        $token = $params [0];
+                        $token = $params[0];
                         if (startsWith($token, 'card')) {
                             $boost = $this->getIconCount($command, $token);
                             $this->userAssertTrue(self::_('Invalid payment'), $boost > 0);
-                            $this->saction_PlayCardsToDiscard($player_id, [ $token ], clienttranslate('${player_name} discards ${token_name} as ship payment'));
+                            $this->saction_PlayCardsToDiscard($player_id, [$token], clienttranslate('${player_name} discards ${token_name} as ship payment'));
                             for ($b = 1; $b < $boost; $b++) {
                                 $this->consumeOperation($rules, $consume, $replace);
                             }
                         } else {
-                            $accomulator [] = $token;
+                            $accomulator[] = $token;
                         }
                         if (count($accomulator) > 0) {
                             if ($lookup !== $command) {
-                                $this->dbSetTokensLocation($accomulator, "stock_fighter", 0, clienttranslate('${player_name} pays ${token_div_count}'), [ 
-                                        'player_id' => $player_id ]);
-                                $accomulator = [ ];
+                                $this->dbSetTokensLocation($accomulator, "stock_fighter", 0, clienttranslate('${player_name} pays ${token_div_count}'), [
+                                    'player_id' => $player_id
+                                ]);
+                                $accomulator = [];
                             }
                         }
                     } else {
@@ -2429,51 +2562,51 @@ class EminentDomain extends EuroGame {
                             $this->userAssertTrue(self::_('You can only have one Battlecruiser'), !$b);
                         }
                         $resourceInfo = $this->dbGetFreeFighterInfo($command);
-                        $accomulator [] = $resourceInfo;
+                        $accomulator[] = $resourceInfo;
                         if ($lookup !== $command) {
-                            $this->dbSetTokensLocation($accomulator, "tableau_$color", 1, clienttranslate('${player_name} gains ${token_div_count}'), [ 
-                                    'player_id' => $player_id ]);
-                            $accomulator = [ ];
+                            $this->dbSetTokensLocation($accomulator, "tableau_$color", 1, clienttranslate('${player_name} gains ${token_div_count}'), [
+                                'player_id' => $player_id
+                            ]);
+                            $accomulator = [];
                         } else {
                             // silent move to change db state, otherwise we will get same fighter
                             $this->tokens->moveToken($resourceInfo['key'], "tableau_$color", 1);
-
                         }
                     }
                     break;
-                case 'y' : // choose resource type
-                    $resourcetype = $params [0];
+                case 'y': // choose resource type
+                    $resourcetype = $params[0];
                     $resourceInfo = $this->dbGetFreeResourceInfo($resourcetype);
-                    $token = $resourceInfo ['key'];
+                    $token = $resourceInfo['key'];
                     $this->dbSetTokenLocation($token, $card, RESOURCE_STATE_MARKER, clienttranslate('${player_name} chooses ${token_name} TYPE'));
                     break;
-                case 'i' :
+                case 'i':
                     $this->saction_GainInfluenceTokens($player_id, 1, $card);
                     $this->notifyAnimate();
                     break;
-              
-                case 'K' :
+
+                case 'K':
                     // recon deck
                     $mydeck = "deck_${color}";
                     $card = array_shift($params);
-                    if ($this->tokens->countTokensInLocation($mydeck)==0) {
+                    if ($this->tokens->countTokensInLocation($mydeck) == 0) {
                         $this->tokens->reformDeckFromDiscard($mydeck);
                     }
                     $info = $this->tokens->getTokenInfo($card);
-                    $this->systemAssertTrue("recon card is not in the deck $card", $info ['location'] === $mydeck);
+                    $this->systemAssertTrue("recon card is not in the deck $card", $info['location'] === $mydeck);
                     $this->tokens->insertTokenOnExtremePosition($card, $mydeck, true);
                     break;
-                case 'L' :
+                case 'L':
                     // recon planet deck
                     $card = array_shift($params);
                     $this->tokens->insertTokenOnExtremePosition($card, "supply_planets", true);
                     $this->revealPlanetSupplyTop();
                     break;
-                case 'x' :
-                        // no-op except discard action card
-                    $consume = $rules [0];
+                case 'x':
+                    // no-op except discard action card
+                    $consume = $rules[0];
                     break;
-                case 'R' : // get tech card
+                case 'R': // get tech card
                     if ($pay) {
                         break;
                     }
@@ -2485,7 +2618,7 @@ class EminentDomain extends EuroGame {
                     if ($this->saction_PayForTech($tech, $color, 0, $choices_arr))
                         $this->saction_BuyTech($tech, $color);
                     break;
-                case 'T' : // get tech card
+                case 'T': // get tech card
                     if ($pay) {
                         break;
                     }
@@ -2503,25 +2636,28 @@ class EminentDomain extends EuroGame {
                     $this->incGameStateValue('actions_allowed', $extra + 0);
                     $allowed = $this->getGameStateValue('actions_allowed');
                     $played = $this->getGameStateValue('action_played');
-                    $this->notifyWithName('playerLog', clienttranslate('${player_name} can play ${extra} more actions, total remaining ${total}'), [ 
-                            'extra' => $extra,'total' => ($allowed - $played) ]);
+                    $this->notifyWithName('playerLog', clienttranslate('${player_name} can play ${extra} more actions, total remaining ${total}'), [
+                        'extra' => $extra, 'total' => ($allowed - $played)
+                    ]);
                     break;
-                case 'O' :
+                case 'O':
                     $this->incGameStateValue('role_phases_allowed', 1);
-                    $this->notifyWithName('playerLog', clienttranslate('${player_name} can play extra role phase this turn'), [ 
-                            'player_id' => $player_id ]);
+                    $this->notifyWithName('playerLog', clienttranslate('${player_name} can play extra role phase this turn'), [
+                        'player_id' => $player_id
+                    ]);
                     break;
-                case 'q' :
+                case 'q':
                     $card = array_shift($params);
-                    $this->systemAssertTrue("bad card for pick $card", $this->tokens->getTokenInfo($card) ['location'] === "hand_$color");
-                    $this->dbSetTokenLocation($card, "tableau_$color", PLANET_UNSETTLED, clienttranslate('You picked ${token_name}'), [ 
-                            'player_id' => $player_id,'log_others' => clienttranslate('${player_name} picked a planet') ]);
+                    $this->systemAssertTrue("bad card for pick $card", $this->tokens->getTokenInfo($card)['location'] === "hand_$color");
+                    $this->dbSetTokenLocation($card, "tableau_$color", PLANET_UNSETTLED, clienttranslate('You picked ${token_name}'), [
+                        'player_id' => $player_id, 'log_others' => clienttranslate('${player_name} picked a planet')
+                    ]);
                     break;
-                case 'Q' :
+                case 'Q':
                     $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "hand_$color");
                     $this->dbSetTokensLocation($tokens, "discard_planets", 1, ''); //discard face up
                     break;
-                case 'g' :
+                case 'g':
                     $tech = array_shift($params);
                     $owner_id = 0;
                     $this->saction_RemoveCardFromGame($tech, $player_id, $owner_id);
@@ -2532,20 +2668,22 @@ class EminentDomain extends EuroGame {
                             // that was improved fleet, we need to rever it
                             $no = $this->getPlayerPosition($owner_id);
                             $newcard = "card_fleet_b_${no}";
-                            $this->dbSetTokenLocation($newcard, "tableau_$owner_color", 2, clienttranslate('${player_name} gets ${token_name}'), [ 
-                                    'player_id' => $owner_id ]);
+                            $this->dbSetTokenLocation($newcard, "tableau_$owner_color", 2, clienttranslate('${player_name} gets ${token_name}'), [
+                                'player_id' => $owner_id
+                            ]);
                             $incplace = $newcard;
                             // marker
                             $total = count($this->tokens->getTokensOfTypeInLocation('vp'));
                             $total++;
                             $maker = $this->tokens->createToken("vp_x_$total", "stock_vp");
-                            $this->dbSetTokenLocation($maker, $newcard, RESOURCE_STATE_COLONIZE_BOOST, clienttranslate('${player_name} marks ${token_name}'), [ 
-                                    'player_id' => $owner_id ]);
+                            $this->dbSetTokenLocation($maker, $newcard, RESOURCE_STATE_COLONIZE_BOOST, clienttranslate('${player_name} marks ${token_name}'), [
+                                'player_id' => $owner_id
+                            ]);
                         }
                         $this->saction_Reparations($owner_id, 2, $incplace);
                     }
                     break;
-                default :
+                default:
                     $this->systemAssertTrue("not supported $command: " . toJson($choices_arr), false);
                     break;
             }
@@ -2556,42 +2694,45 @@ class EminentDomain extends EuroGame {
             }
             $i++;
         }
-
     }
 
-    function saction_ValidateRestOfChoices(&$choices_arr, $orig_rules = '') {
+    function saction_ValidateRestOfChoices(&$choices_arr, $orig_rules = '')
+    {
         while (count($choices_arr) > 0) {
             $rest = toJson($choices_arr);
             $params = array_shift($choices_arr);
-            if ( !is_array($params))
+            if (!is_array($params))
                 $this->systemAssertTrue("bad operation not array $params");
             $command = array_shift($params);
             switch ($command) {
-                case 'z' : // end marker
-                case 'x' : // no-op marker
-                case 'R' : // research unused
-                case 'E' : // remove any card optional
-                case 'e' : // remove any card optional
+                case 'z': // end marker
+                case 'x': // no-op marker
+                case 'R': // research unused
+                case 'E': // remove any card optional
+                case 'e': // remove any card optional
                     break;
-                default :
+                default:
                     $this->systemAssertTrue("No matching action for $rest full rules [$orig_rules]");
             }
         }
     }
 
-    function saction_PlayCardsToDiscard($player_id, $cards, $notif = '*') {
+    function saction_PlayCardsToDiscard($player_id, $cards, $notif = '*')
+    {
         if ($notif == '*')
             $notif = clienttranslate('${player_name} discards ${token_names}');
         $this->saction_PlayCardsToPlayerZone($player_id, $cards, 'discard', CARD_STATE_FACEUP, $notif);
     }
 
-    function saction_PlayCardsToAside($player_id, $cards, $notif, $state = CARD_STATE_USED_CARD) {
+    function saction_PlayCardsToAside($player_id, $cards, $notif, $state = CARD_STATE_USED_CARD)
+    {
         if ($notif == '*')
             $notif = clienttranslate('${player_name} plays ${token_names}');
         $this->saction_PlayCardsToPlayerZone($player_id, $cards, 'setaside', $state, $notif);
     }
 
-    function saction_PlayCardsToPlayerZone($player_id, $cards, $zone, $state = null, $notif = '*') {
+    function saction_PlayCardsToPlayerZone($player_id, $cards, $zone, $state = null, $notif = '*')
+    {
         if ($this->tokens->checkListOrTokenArray($cards) == 0)
             return;
         $color = $this->getPlayerColor($player_id);
@@ -2599,42 +2740,48 @@ class EminentDomain extends EuroGame {
             $notif = clienttranslate('${player_name} plays ${token_names} into ${place_name}');
         $target = "${zone}_$color";
         $plus = count($cards) > 1;
-        $this->dbSetTokensLocation($cards, $target, $state, $notif, [ 'player_id' => $player_id,'nod' => $plus ]);
+        $this->dbSetTokensLocation($cards, $target, $state, $notif, ['player_id' => $player_id, 'nod' => $plus]);
         if ($plus || $zone == 'discard') // discard require extra time because it moves + fades
             $this->notifyAnimate();
     }
 
-    function saction_AutoReplenish($card_id, $color, $info = null) {
+    function saction_AutoReplenish($card_id, $color, $info = null)
+    {
         $rule = $this->getRulesFor($card_id, 'rslots');
         if ($rule) {
             $player_id = $this->getPlayerIdByColor($color);
-            if ($info && $this->isPlanet($card_id) && array_value_get($info,'state') == 0)
+            if ($info && $this->isPlanet($card_id) && array_value_get($info, 'state') == 0)
                 return;
             $tokens = $this->tokens->getTokensOfTypeInLocation(null, $card_id);
-            foreach ( $tokens as $key => $info2 ) {
+            foreach ($tokens as $key => $info2) {
                 $restype = getPart($key, 1); // i.e F,B
                 $rule = preg_replace("/$restype/", "", $rule, 1);
             }
             if ($rule) { // anything left untaken?
                 for ($i = 0; $i < strlen($rule); $i++) {
-                    $command = $rule [$i];
+                    $command = $rule[$i];
                     $resourceInfo = $this->dbGetFreeFighterInfo($command);
-                    $this->dbSetTokenLocation($resourceInfo['key'], $card_id, $player_id,
-                            clienttranslate('game replenishes slot of ${place_name} with ${token_name}'));
+                    $this->dbSetTokenLocation(
+                        $resourceInfo['key'],
+                        $card_id,
+                        $player_id,
+                        clienttranslate('game replenishes slot of ${place_name} with ${token_name}')
+                    );
                 }
             }
         }
     }
 
-    function saction_TurnReplenish($player_id) {
+    function saction_TurnReplenish($player_id)
+    {
         $color = $this->getPlayerColor($player_id);
         // replenish regeneratable slots and init turn
         $tokens = $this->tokens->getTokensOfTypeInLocation("card", "tableau_${color}");
-        foreach ( $tokens as $key => $info ) {
+        foreach ($tokens as $key => $info) {
             $this->saction_AutoReplenish($key, $color, $info);
         }
-   
-        
+
+
         $this->setGameStateValue('leader', $player_id);
         $this->setGameStateValue('action_played', 0);
         $this->setGameStateValue('followers', 0);
@@ -2652,17 +2799,23 @@ class EminentDomain extends EuroGame {
         // XXX
     }
 
-    function saction_IndustrialEspionage($player_id, $card) {
+    function saction_IndustrialEspionage($player_id, $card)
+    {
         $this->systemAssertTrue("incorrect card $card for special action", $card == 'card_tech_E_11');
         $players = $this->loadPlayersBasicInfos();
-        foreach ( $players as $player_id_o => $player_info ) {
+        foreach ($players as $player_id_o => $player_info) {
             if ($player_id_o != $player_id) {
-                $vps = $this->dbGetOwnVpInfo($player_info ['player_color']);
+                $vps = $this->dbGetOwnVpInfo($player_info['player_color']);
                 $vp = array_shift($vps);
                 if ($vp) {
-                    $this->dbIncScoreValueAndNotify($player_id, -1, '', 'game_vptrade', [ 'player_id' => $player_id ]);
-                    $this->dbSetTokensLocation([ $vp ], 'stock_vp', 0, clienttranslate('${player_name} returns ${token_div_count} to supply'), [ 
-                            'player_id' => $player_id_o ]);
+                    $this->dbIncScoreValueAndNotify($player_id, -1, '', 'game_vptrade', ['player_id' => $player_id]);
+                    $this->dbSetTokensLocation([$vp], 'stock_vp', 0, clienttranslate('${player_name} returns ${token_div_count} to supply'), [
+                        'player_id' => $player_id_o
+                    ]);
+                    $color = $this->getPlayerColor($player_id_o);
+                    $score = count($this->tokens->getTokensOfTypeInLocation('vp', "tableau_$color"));
+                    $this->notifyCounterDirect("vp_${color}_counter", $score, '', ['place' => $card, 'inc' => -1]);
+                    $this->notifyCounter("stock_vp");
                 }
             }
         }
@@ -2670,35 +2823,40 @@ class EminentDomain extends EuroGame {
         $this->notifyAnimate();
     }
 
-    function saction_Reparations($player_id, $inc = 2, $place = null) {
+    function saction_Reparations($player_id, $inc = 2, $place = null)
+    {
         $color = $this->getPlayerColor($player_id);
         if ($place == null)
             $place = "tableau_$color";
-        $this->dbIncScoreValueAndNotify($player_id, $inc, '', 'game_reparations', [ 'place' => $place,'noa' => true ]);
+        $this->dbIncScoreValueAndNotify($player_id, $inc, '', 'game_reparations', ['place' => $place, 'noa' => true]);
         $vp_tokens = $this->dbGetFreeVpTokens($inc);
-        $this->dbSetTokensLocation($vp_tokens, "tableau_$color", 1, clienttranslate('${player_name} gains ${token_div_count} from ${place_from} as REPARATIONS'), [ 
-                'player_id' => $player_id,'place_from' => $place,'noa' => true  ]);
+        $this->dbSetTokensLocation($vp_tokens, "tableau_$color", 1, clienttranslate('${player_name} gains ${token_div_count} from ${place_from} as REPARATIONS'), [
+            'player_id' => $player_id, 'place_from' => $place, 'noa' => true
+        ]);
         $score = count($this->tokens->getTokensOfTypeInLocation('vp', "tableau_$color"));
-        $this->notifyCounterDirect("vp_${color}_counter", $score, '', [ 'place' => $place,'inc' => $inc ]);
+        $this->notifyCounterDirect("vp_${color}_counter", $score, '', ['place' => $place, 'inc' => $inc]);
         $this->notifyCounter("stock_vp");
     }
-    
-    
-    function saction_GainInfluenceTokens($player_id, $inc, $place) {
+
+
+    function saction_GainInfluenceTokens($player_id, $inc, $place)
+    {
         $color = $this->getPlayerColor($player_id);
         if (startsWith($place, "x")) {
             $place = "tableau_$color";
         }
-        $this->dbIncScoreValueAndNotify($player_id, $inc, '', 'game_vptrade', [ 'place_name' => $place ]);
+        $this->dbIncScoreValueAndNotify($player_id, $inc, '', 'game_vptrade', ['place_name' => $place]);
         $vp_tokens = $this->dbGetFreeVpTokens($inc);
         $this->dbSetTokensLocation($vp_tokens, "tableau_$color", 1, clienttranslate('${player_name} gains ${token_div_count} from ${place_from}'), [
-                'player_id' => $player_id,'place_from' => $place ]);
+            'player_id' => $player_id, 'place_from' => $place
+        ]);
         $score = count($this->tokens->getTokensOfTypeInLocation('vp', "tableau_$color"));
-        $this->notifyCounterDirect("vp_${color}_counter", $score, '', [ 'place' => $place,'inc' => $inc ]);
+        $this->notifyCounterDirect("vp_${color}_counter", $score, '', ['place' => $place, 'inc' => $inc]);
         $this->notifyCounter("stock_vp");
     }
 
-    function query_revealContents($place) {
+    function query_revealContents($place)
+    {
         // self::checkAction('showDiscard');
         // no action restrictions 
         $player_id = $this->getCurrentPlayerId();
@@ -2715,85 +2873,96 @@ class EminentDomain extends EuroGame {
      * These methods function is to return some additional information that is specific to the current
      * game state.
      */
-    function arg_playerTurnAction() {
+    function arg_playerTurnAction()
+    {
         $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
         $res = $this->arg_playerTurnExtra($player_id);
         $res += $this->arg_playerTurnRole();
         // Logistics, untapped
-        $res ['can_play_role_first'] = $this->playerHasCard('card_tech_3_86', $color);
+        $res['can_play_role_first'] = $this->playerHasCard('card_tech_3_86', $color);
         return $res + [
-                'action_played' => $this->getGameStateValue('action_played'),
-                'actions_allowed' => $this->getGameStateValue('actions_allowed'),
+            'action_played' => $this->getGameStateValue('action_played'),
+            'actions_allowed' => $this->getGameStateValue('actions_allowed'),
         ];
     }
 
-    function arg_playerTurnRole() {
+    function arg_playerTurnRole()
+    {
         $player_id = $this->getActivePlayerId();
 
-        $pinfo = [ ];
-        $pinfo [$player_id] = $this->arg_playerTurnInfo($player_id,'l-.');
+        $pinfo = [];
+        $pinfo[$player_id] = $this->arg_playerTurnInfo($player_id, 'l-.');
         $triggered = $this->isEndOfGameTriggered();
         $extra_played = $this->getGameStateValue('extra_turn_at_end') == 1;
-        $res = array ('pinfo' => $pinfo,'end_of_game' => $triggered,'extra_turn' => $extra_played,
-                'role_phases_played' => $this->getGameStateValue('role_phases_played'),
-                'role_phases_allowed' => $this->getGameStateValue('role_phases_allowed'),
-                'leader' => $player_id, );
+        $res = array(
+            'pinfo' => $pinfo, 'end_of_game' => $triggered, 'extra_turn' => $extra_played,
+            'role_phases_played' => $this->getGameStateValue('role_phases_played'),
+            'role_phases_allowed' => $this->getGameStateValue('role_phases_allowed'),
+            'leader' => $player_id,
+        );
 
-        $res = array_merge($res, $pinfo [$player_id]);
+        $res = array_merge($res, $pinfo[$player_id]);
         return $res;
     }
 
-    function arg_playerTurnFollow() {
+    function arg_playerTurnFollow()
+    {
         $role_index = $this->getGameStateValue('role');
-        $role = $this->materials ['role_icons'] [$role_index];
-        $role_name = $this->materials ['icons'] [$role];
+        $role = $this->materials['role_icons'][$role_index];
+        $role_name = $this->materials['icons'][$role];
         $leader = $this->getGameStateValue('leader');
         $active_follower = $this->getGameStateValue('active_follower');
-        $pinfo = [ ];
+        $pinfo = [];
         $players = $this->loadPlayersBasicInfos();
-        foreach ( $players as $player_id_o => $player_info ) {
+        foreach ($players as $player_id_o => $player_info) {
             // that should have been private...
-            $pinfo [$player_id_o] = $this->arg_playerTurnInfo($player_id_o, "f-" . $role);
-            $canFollow = $this->canFollowOnInfo( $pinfo [$player_id_o], $role,$player_id_o);
-            $pinfo [$player_id_o]['can_follow']=$canFollow;
+            $pinfo[$player_id_o] = $this->arg_playerTurnInfo($player_id_o, "f-" . $role);
+            $canFollow = $this->canFollowOnInfo($pinfo[$player_id_o], $role, $player_id_o);
+            $pinfo[$player_id_o]['can_follow'] = $canFollow;
         }
-        $leader_name = $players [$leader] ['player_name'];
+        $leader_name = $players[$leader]['player_name'];
         $triggered = $this->isEndOfGameTriggered();
         $extra_played = $this->getGameStateValue('extra_turn_at_end') == 1;
-        $res = array ('pinfo' => $pinfo,'leader' => $leader,'otherplayer_id' => $leader,'otherplayer' => $leader_name,
-                'role' => $role,'active_follower' => $active_follower,'role_name' => $role_name,
-                'i18n' => [ 'role_name' ],'end_of_game' => $triggered,'extra_turn' => $extra_played, );
+        $res = array(
+            'pinfo' => $pinfo, 'leader' => $leader, 'otherplayer_id' => $leader, 'otherplayer' => $leader_name,
+            'role' => $role, 'active_follower' => $active_follower, 'role_name' => $role_name,
+            'i18n' => ['role_name'], 'end_of_game' => $triggered, 'extra_turn' => $extra_played,
+        );
         return $res;
     }
 
-    function arg_playerTurnInfo($player_id, $event='') {
+    function arg_playerTurnInfo($player_id, $event = '')
+    {
         $color = $this->getPlayerColor($player_id);
         $settle = $this->arg_planets($color);
         $holdres = $this->arg_holders($color);
-        $res = array ('planets' => $settle,'holders' => $holdres,'tech' => $this->arg_research($color),
-                'boost_rem' => $this->getGameStateValue('boost_rem'),
-                'fdiscount'=> $this->arg_attackDiscount($color)
-                
+        $res = array(
+            'planets' => $settle, 'holders' => $holdres, 'tech' => $this->arg_research($color),
+            'boost_rem' => $this->getGameStateValue('boost_rem'),
+            'fdiscount' => $this->arg_attackDiscount($color)
+
         );
-        $icons = $this->materials ['role_icons'];
+        $icons = $this->materials['role_icons'];
         $ii = $this->arg_iconsInfo($color, $icons, $event);
         $res = array_merge($res, $ii);
         return $res;
     }
 
-    function arg_playerTurnRoleExtra($player_id = -1) {
+    function arg_playerTurnRoleExtra($player_id = -1)
+    {
         if ($player_id == -1)
             $player_id = $this->getActivePlayerId();
         $res = $this->arg_playerTurnExtra($player_id);
-        if ($res ['enabled']) {
+        if ($res['enabled']) {
             $pinfo = $this->arg_playerTurnInfo($player_id);
             return $res + $pinfo;
         }
         return $res;
     }
 
-    function arg_attackDiscount($color) {
+    function arg_attackDiscount($color)
+    {
         $fdiscount = 0;
         $b = $this->tokens->getTokenOfTypeInLocation("fighter_B", "tableau_$color");
         if ($b) { // battlecruiser in play
@@ -2809,84 +2978,86 @@ class EminentDomain extends EuroGame {
         return $fdiscount;
     }
 
-    function arg_playerTurnExtra($player_id = -1) {
+    function arg_playerTurnExtra($player_id = -1)
+    {
         if ($player_id == -1)
             $player_id = $this->getActivePlayerId();
         $color = $this->getPlayerColor($player_id);
-        $cards = $this->tokens->getTokensOfTypeInLocation("card", "setaside_$color", CARD_STATE_PARTIAL_ACTION)// 
-               + $this->tokens->getTokensOfTypeInLocation("card", "tableau_$color", CARD_STATE_PARTIAL_ACTION);
+        $cards = $this->tokens->getTokensOfTypeInLocation("card", "setaside_$color", CARD_STATE_PARTIAL_ACTION) // 
+            + $this->tokens->getTokensOfTypeInLocation("card", "tableau_$color", CARD_STATE_PARTIAL_ACTION);
         if (count($cards) > 0) {
-            $data = [ 'enabled' => true ];
-            $data ['state_prompt'] = ('must resolve rest of the action');
-            $data ['i18n']=['state_prompt'];
+            $data = ['enabled' => true];
+            $data['state_prompt'] = ('must resolve rest of the action');
+            $data['i18n'] = ['state_prompt'];
             $card = array_shift($cards);
-            $data ['card'] = $card ['key']; // unfinished action
-            $data ['rules'] = $this->getRulesByNum($card ['key'], CARD_RULE_ACTION_PART2);
+            $data['card'] = $card['key']; // unfinished action
+            $data['rules'] = $this->getRulesByNum($card['key'], CARD_RULE_ACTION_PART2);
             return $data;
         }
         $pending_info = $this->peekAbility();
         $planets = $this->tokens->getTokensOfTypeInLocation("card_planet", "hand_$color");
-        if ($pending_info && $pending_info ['card'] === 'card_tech_E_24') { // thur sur XXX very ugly
+        if ($pending_info && $pending_info['card'] === 'card_tech_E_24') { // thur sur XXX very ugly
             // skip planet pick
         } else {
             if (count($planets) > 0) {
-                $data = [ 'enabled' => true,'survey' => true ];
-                $data ['state_prompt'] = clienttranslate('must choose a planet to keep');
-                $data ['i18n'] = [ 'state_prompt' ];
-                $data ['card'] = "survey";
-                $data ['rules'] = "qQ";
+                $data = ['enabled' => true, 'survey' => true];
+                $data['state_prompt'] = clienttranslate('must choose a planet to keep');
+                $data['i18n'] = ['state_prompt'];
+                $data['card'] = "survey";
+                $data['rules'] = "qQ";
                 return $data;
             }
         }
-            //$triginfo = [ 'card' => $card_id,'num' => $num,'rules' => $rules,'actor_color' => $color ];
+        //$triginfo = [ 'card' => $card_id,'num' => $num,'rules' => $rules,'actor_color' => $color ];
 
         if ($pending_info) {
-            if ($pending_info ['actor_color'] === $color) {
-                    // for now it must be active player
-                $data = [ 'enabled' => true,'extra' => true ];
-                $data ['state_prompt'] = clienttranslate('must resolve triggered ability');
-                $data ['rules'] = $pending_info ['rules'];
-                $data ['card'] = $pending_info ['card'];
-                $data ['i18n'] = [ 'state_prompt' ];
+            if ($pending_info['actor_color'] === $color) {
+                // for now it must be active player
+                $data = ['enabled' => true, 'extra' => true];
+                $data['state_prompt'] = clienttranslate('must resolve triggered ability');
+                $data['rules'] = $pending_info['rules'];
+                $data['card'] = $pending_info['card'];
+                $data['i18n'] = ['state_prompt'];
                 return $data;
             } else {
-                $this->error("out of turn trigger for $color ". toJson($pending_info));
+                $this->error("out of turn trigger for $color " . toJson($pending_info));
             }
         }
-        return [ 'state_prompt' => '','enabled' => false ];
+        return ['state_prompt' => '', 'enabled' => false];
     }
 
 
 
-    function arg_iconsInfo($color, $icons, $event='') {
-        $res = [ ];
+    function arg_iconsInfo($color, $icons, $event = '')
+    {
+        $res = [];
         if (is_string($icons))
-            $icons = str_split( $icons);
+            $icons = str_split($icons);
         $tokens = $this->tokens->getTokensOfTypeInLocation("card", "tableau_${color}", 1);
         $cardsInHand = $this->tokens->getTokensOfTypeInLocation("card", "hand_${color}");
         if (!$event) {
             $player_id = $this->getPlayerIdByColor($color);
             $leader_id = $this->getGameStateValue('leader');
             if ($player_id != $leader_id) { // follow 
-                $event="f-.";
+                $event = "f-.";
             } else {
-                $event="l-.";
+                $event = "l-.";
             }
         }
         $hsize = 5;
-        foreach ( $tokens as $card => $info ) {
+        foreach ($tokens as $card => $info) {
             $handplus = $this->getRulesFor($card, 'h');
             if ($handplus)
                 $hsize += $handplus;
         }
-        $res ['hand_size'] = $hsize;
+        $res['hand_size'] = $hsize;
         $bureacracy = false;
-        $jokers = [ ];
-        foreach ( $icons as $icon ) {
-            $jokers [$icon] = '';
+        $jokers = [];
+        foreach ($icons as $icon) {
+            $jokers[$icon] = '';
         }
         $bureacracy = $this->playerHasCard('card_tech_3_97', $color);
-        foreach ( $tokens as $card => $info ) {
+        foreach ($tokens as $card => $info) {
             if ($card === 'card_tech_3_76') { //Adaptability
                 $this->iconReplacement($jokers, $icons, $event, '[lf]-.:R');
             } else if ($card === 'card_tech_E_31') { //wealth of knowledge
@@ -2896,9 +3067,9 @@ class EminentDomain extends EuroGame {
             } else if ($card === 'card_tech_E_32') { //WARFARE TECHNOLOGY
                 $this->iconReplacement($jokers, $icons, $event, '[lf]-R:F');
             }
-        }        
+        }
         $res_tokens = $this->tokens->getTokensOfTypeInLocation("fighter", "tableau_${color}");
-        foreach ( $tokens as $card => $info ) {
+        foreach ($tokens as $card => $info) {
             $count = $this->getRulesFor($card, 'slots');
             if ($count) {
                 $res_tokens += $this->tokens->getTokensOfTypeInLocation("resource", $card);
@@ -2908,168 +3079,171 @@ class EminentDomain extends EuroGame {
                 $res_tokens += $this->tokens->getTokensOfTypeInLocation("fighter", $card, "!=1");
             }
         }
-        
 
-        foreach ( $icons as $icon ) {
+
+        foreach ($icons as $icon) {
             if ($icon === 'h')
                 continue;
-            $res ['perm_boost'] [$icon] = [ ];
-            $res ['perm_boost_num'] [$icon] = 0;
-            $res ['hand_boost'] [$icon] = [ ];
-            $res ['hand_boost_num'] [$icon] = 0;
-            foreach ( $tokens as $card => $info ) {
+            $res['perm_boost'][$icon] = [];
+            $res['perm_boost_num'][$icon] = 0;
+            $res['hand_boost'][$icon] = [];
+            $res['hand_boost_num'][$icon] = 0;
+            foreach ($tokens as $card => $info) {
                 $count = $this->getIconCount($icon, $card);
                 if ($count) {
-                    $res ['perm_boost'] [$icon] [$card] = $count;
+                    $res['perm_boost'][$icon][$card] = $count;
                 }
             }
             if ($bureacracy) {
                 if ($this->mtMatchEvent('f-[^C]', $event)) {
-                    $res ['perm_boost'] [$icon] [$bureacracy] = 1;
+                    $res['perm_boost'][$icon][$bureacracy] = 1;
                 }
             }
-            foreach ( $res ['perm_boost'] [$icon] as $card => $count ) {
-                $res ['perm_boost_num'] [$icon] += $count;
+            foreach ($res['perm_boost'][$icon] as $card => $count) {
+                $res['perm_boost_num'][$icon] += $count;
             }
             $search = $cardsInHand + $res_tokens;
-            foreach ( $search as $card => $info ) {
-                $count = $this->getIconCount($icon, $card, $jokers [$icon]);
+            foreach ($search as $card => $info) {
+                $count = $this->getIconCount($icon, $card, $jokers[$icon]);
                 if ($count) {
-                    $res ['hand_boost'] [$icon] [$card] = $count;
-                    $res ['hand_boost_num'] [$icon] += $count;
+                    $res['hand_boost'][$icon][$card] = $count;
+                    $res['hand_boost_num'][$icon] += $count;
                 }
             }
         }
         return $res;
     }
 
-    function arg_research($color, $atech = null, $details = false) {
-        $res = [ ];
+    function arg_research($color, $atech = null, $details = false)
+    {
+        $res = [];
         $fighters = $this->dbGetOwnFighterInfo($color);
         $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "tableau_${color}");
-        $own_type = [ ];
-        $ptypes = $this->materials ['planet_types'];
-        foreach ( $ptypes as $type => $name ) {
-            $own_type [$type] = [ ];
+        $own_type = [];
+        $ptypes = $this->materials['planet_types'];
+        foreach ($ptypes as $type => $name) {
+            $own_type[$type] = [];
         }
-        foreach ( $tokens as $planet => $info ) {
-            $state = $info ['state'];
+        foreach ($tokens as $planet => $info) {
+            $state = $info['state'];
             if ($state > 0 && $state != CARD_STATE_PLANET_USED_AS_REQ) {
-                $type = $this->token_types [$planet] ['t'];
-                $own_type [$type] [] = $planet;
+                $type = $this->token_types[$planet]['t'];
+                $own_type[$type][] = $planet;
             }
         }
         if ($atech == null) {
             $techs = $this->tokens->getTokensOfTypeInLocation(null, "supply_tech_%");
             $ownfleet = $this->tokens->getTokenOfTypeInLocation('card_fleet', "tableau_${color}");
-            if ($ownfleet && getPart($ownfleet ['key'], 2) == 'b') {
+            if ($ownfleet && getPart($ownfleet['key'], 2) == 'b') {
                 $fleet = $this->tokens->getTokensInLocation("supply_fleet");
                 if (count($fleet) > 0) {
                     $ifleet = array_shift($fleet);
-                    $techs [$ifleet ['key']] = $ifleet;
+                    $techs[$ifleet['key']] = $ifleet;
                 }
             }
         } else {
             $info = $this->tokens->getTokenInfo($atech);
-            $techs [$info ['key']] = $info;
+            $techs[$info['key']] = $info;
         }
-        foreach ( $techs as $tech => $info ) {
+        foreach ($techs as $tech => $info) {
             $reqs = $this->getRulesFor($tech, 'p');
-            $allfound = [ ];
+            $allfound = [];
             $own_copy = $own_type;
             for ($i = 0; $i < strlen($reqs); $i++) {
-                $req = $reqs [$i];
+                $req = $reqs[$i];
                 if ($req == 'N') {
-                    $req = $reqs [$i - 1];
-                    foreach ( $ptypes as $type => $name ) {
+                    $req = $reqs[$i - 1];
+                    foreach ($ptypes as $type => $name) {
                         if ($type === $req || $type === 'U')
                             continue;
-                        if (count($own_copy [$type]) > 0) {
-                            $allfound [] = array_shift($own_copy [$type]);
+                        if (count($own_copy[$type]) > 0) {
+                            $allfound[] = array_shift($own_copy[$type]);
                             break;
                         }
                     }
                     continue;
                 }
-                if (count($own_copy [$req]) == 0) {
+                if (count($own_copy[$req]) == 0) {
                     $req = 'U';
-                    if (count($own_copy [$req]) > 0) {
-                        $allfound [] = array_shift($own_copy [$req]);
+                    if (count($own_copy[$req]) > 0) {
+                        $allfound[] = array_shift($own_copy[$req]);
                     }
                 } else {
-                    $allfound [] = array_shift($own_copy [$req]);
+                    $allfound[] = array_shift($own_copy[$req]);
                 }
             }
             if (count($allfound) < strlen($reqs))
                 continue;
             $mrec = $this->mtGetFightCost($tech, 'bm');
-            $res [$tech] = [ ];
+            $res[$tech] = [];
             //$res [$tech] ['prereq'] = true;
             if ($details)
-                $res [$tech] ['pl'] = $allfound;
-            $res [$tech] ['bm'] = $mrec ['cost'] . $mrec ['ship_type'];
-            $res [$tech] ['b'] = $this->getRulesFor($tech, 'b');
-            $res [$tech] ['canattack'] = false;
-            $ftype = $mrec ['ship_type'];
-            if ($mrec ['cost'] > 0 && count($fighters [$ftype]) >= $mrec ['cost']) {
-                $res [$tech] ['canattack'] = true;
+                $res[$tech]['pl'] = $allfound;
+            $res[$tech]['bm'] = $mrec['cost'] . $mrec['ship_type'];
+            $res[$tech]['b'] = $this->getRulesFor($tech, 'b');
+            $res[$tech]['canattack'] = false;
+            $ftype = $mrec['ship_type'];
+            if ($mrec['cost'] > 0 && count($fighters[$ftype]) >= $mrec['cost']) {
+                $res[$tech]['canattack'] = true;
             }
         }
         //$this->warn(toJson($res));
         return $res;
     }
 
-    function arg_planets($color) {
+    function arg_planets($color)
+    {
         $perm_boost = $this->getSettleBoost($color);
         $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "tableau_${color}");
-        $res = array ();
+        $res = array();
         //$adaptability = $this->playerHasCard('card_tech_3_76', $color);
-        foreach ( $tokens as $planet => $info ) {
-            $state = $info ['state'];
-            $colonies = $this->token_types [$planet] ['c'];
-            $res [$planet] ['settled'] = $state;
+        foreach ($tokens as $planet => $info) {
+            $state = $info['state'];
+            $colonies = $this->token_types[$planet]['c'];
+            $res[$planet]['settled'] = $state;
             if ($state == 0) {
                 $tokens = $this->tokens->getTokensInLocation($planet);
-                $count = $this->getIconCount('C', $tokens,'*');
+                $count = $this->getIconCount('C', $tokens, '*');
                 if ($count + $perm_boost >= $colonies) {
                     // ready
-                    $res [$planet] ['ready'] = true;
+                    $res[$planet]['ready'] = true;
                 } else {
-                    $res [$planet] ['need'] = $colonies - ($count + $perm_boost);
+                    $res[$planet]['need'] = $colonies - ($count + $perm_boost);
                     // not ready
                 }
             }
         }
         $colship = $this->playerHasCard('card_tech_E_21', $color, true);
         if ($colship) {
-            $planet=$colship;
-            $res [$planet] = [
-                    'settled' => 0,
-                    'ready' => false,
-                    'need' => 1000,
+            $planet = $colship;
+            $res[$planet] = [
+                'settled' => 0,
+                'ready' => false,
+                'need' => 1000,
             ];
         }
-        
+
         return $res;
     }
 
 
-    function arg_holders($color) {
-        $res = array ();
+    function arg_holders($color)
+    {
+        $res = array();
         $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "tableau_${color}", 1) + //
-              $this->tokens->getTokensOfTypeInLocation("card_tech", "tableau_${color}", 1);
+            $this->tokens->getTokensOfTypeInLocation("card_tech", "tableau_${color}", 1);
         $harvest = $this->playerHasCard('scenario_3', $color);
-        foreach ( $tokens as $planet => $info ) {
-            $production = $this->token_types [$planet] ['slots'] ?? '';
-            if ( !$production)
+        foreach ($tokens as $planet => $info) {
+            $production = $this->token_types[$planet]['slots'] ?? '';
+            if (!$production)
                 continue;
             $tokens = $this->tokens->getTokensInLocation($planet);
-            foreach ( $tokens as $rkey => $rinfo ) {
-                if (startsWith($rkey, 'fighter') && $rinfo ['state'] == RESOURCE_STATE_BLOCKER) {
+            foreach ($tokens as $rkey => $rinfo) {
+                if (startsWith($rkey, 'fighter') && $rinfo['state'] == RESOURCE_STATE_BLOCKER) {
                     continue 2; // production blocked 
                 }
             }
-            
+
 
             $is_planet = startsWith($planet, 'card_planet');
             if ($is_planet)
@@ -3078,16 +3252,16 @@ class EminentDomain extends EuroGame {
                 $mod = 1;
             $count = count($tokens);
 
-            $res [$planet] ['resarr'] = [ ];
+            $res[$planet]['resarr'] = [];
             $production_arr = str_split($production);
-            foreach ( $production_arr as $c ) {
+            foreach ($production_arr as $c) {
                 for ($j = 0; $j < $mod; $j++) {
-                    $res [$planet] ['slotsarr'] [$c] [] = 0;
+                    $res[$planet]['slotsarr'][$c][] = 0;
                 }
-                $res [$planet] ['resf'] [$c] = 0;
+                $res[$planet]['resf'][$c] = 0;
             }
-            $count=0;
-            foreach ( $tokens as $rkey => $rinfo ) {
+            $count = 0;
+            foreach ($tokens as $rkey => $rinfo) {
                 if (startsWith($rkey, 'abi')) {
                     continue; // triggred marker
                 }
@@ -3097,25 +3271,25 @@ class EminentDomain extends EuroGame {
                 $count++;
                 $c = $this->getRulesFor($rkey, 'p');
                 // occupied slots
-                if ( !$this->fillSlot($res [$planet] ['slotsarr'], $c)) {
+                if (!$this->fillSlot($res[$planet]['slotsarr'], $c)) {
                     $this->error("cannot find slot for $c at $planet");
                     continue;
                 }
                 // resources to trade
-                array_value_inc($res [$planet] ['resarr'], $c);
+                array_value_inc($res[$planet]['resarr'], $c);
             }
-            $res [$planet] ['resslots'] = strlen($production) * $mod - $count;
-            $res [$planet] ['produced'] = $count;
+            $res[$planet]['resslots'] = strlen($production) * $mod - $count;
+            $res[$planet]['produced'] = $count;
             // empty slots
-            foreach ( $production_arr as $c ) {
-                $mod = count($res [$planet] ['slotsarr'] [$c]);
+            foreach ($production_arr as $c) {
+                $mod = count($res[$planet]['slotsarr'][$c]);
                 for ($j = 0; $j < $mod; $j++) {
-                    if ($res [$planet] ['slotsarr'] [$c] [$j] === 0) {
-                        array_value_inc($res [$planet] ['resf'], $c);
+                    if ($res[$planet]['slotsarr'][$c][$j] === 0) {
+                        array_value_inc($res[$planet]['resf'], $c);
                     }
                 }
             }
-            unset($res [$planet] ['slotsarr']);
+            unset($res[$planet]['slotsarr']);
         }
         return $res;
     }
@@ -3127,7 +3301,8 @@ class EminentDomain extends EuroGame {
      * Here, you can create methods defined as "game state actions" (see "action" property in states.inc.php).
      * The action method of state X is called everytime the current game state is set to X.
      */
-    function st_gameTurnNextPlayer() {
+    function st_gameTurnNextPlayer()
+    {
         $player_id = $this->getGameStateValue('leader');
         $extra_played = false;
         $extra_turn = $this->getGameStateValue('extra_turn_variant') == 2;
@@ -3143,15 +3318,16 @@ class EminentDomain extends EuroGame {
         $next_player_id = $this->getPlayerAfter($player_id);
         if ($this->isEndOfGame($next_player_id)) {
             $logistics = false;
-            if ( !$extra_turn || $extra_played) {
+            if (!$extra_turn || $extra_played) {
                 $players = $this->loadPlayersBasicInfos();
-                foreach ( $players as $player_id1 => $player_info ) {
+                foreach ($players as $player_id1 => $player_info) {
                     $color1 = $this->getPlayerColor($player_id1);
                     $logistics = $this->playerHasCard('card_tech_3_86', $color1);
                     if ($logistics) {
                         $this->setGameStateValue('logistics_at_end', 1);
-                        $this->notifyWithName('playerLog', clienttranslate('${player_name} activates extra turn at the end of game with Logistics'), [ 
-                                'player_id' => $player_id1 ]);
+                        $this->notifyWithName('playerLog', clienttranslate('${player_name} activates extra turn at the end of game with Logistics'), [
+                            'player_id' => $player_id1
+                        ]);
                         $next_player_id = $player_id1;
                         break;
                     }
@@ -3160,7 +3336,7 @@ class EminentDomain extends EuroGame {
             if ($extra_turn && !$extra_played) {
                 $this->setGameStateValue('extra_turn_at_end', 1);
             } else {
-                if ( !$logistics) {
+                if (!$logistics) {
                     $this->finalScoring();
                     $this->gamestate->nextState('last');
                     return;
@@ -3172,12 +3348,14 @@ class EminentDomain extends EuroGame {
         $this->gamestate->nextState('next');
     }
 
-    protected function isPlayerZombie($player_id) {
+    protected function isPlayerZombie($player_id)
+    {
         $players = self::loadPlayersBasicInfos();
-        return ($players [$player_id] ['player_zombie'] == 1);
+        return ($players[$player_id]['player_zombie'] == 1);
     }
 
-    function st_gameTurnUpkeep() {
+    function st_gameTurnUpkeep()
+    {
         // end of role dispatch
         $this->setGameStateValue('follow_played', 1);
         $player_id = $this->getGameStateValue('leader');
@@ -3188,25 +3366,25 @@ class EminentDomain extends EuroGame {
             return;
         }
         $color = $this->getPlayerColor($player_id);
-            // triggered abilities on stack
+        // triggered abilities on stack
         $args = $this->arg_playerTurnExtra($player_id);
-        if ($args ['enabled']) {
+        if ($args['enabled']) {
             $this->gamestate->nextState('extra');
             return;
         }
-        
+
         // end of role phase cleanup
         $players = $this->loadPlayersBasicInfos();
-        foreach ( $players as $player_info ) {
-            $pcolor = $player_info ['player_color'];
+        foreach ($players as $player_info) {
+            $pcolor = $player_info['player_color'];
             // unmark used planets for all players (for scientific method)
             $tokens = $this->tokens->getTokensOfTypeInLocation("card_planet", "tableau_${pcolor}", CARD_STATE_PLANET_USED_AS_REQ);
-            $this->dbSetTokensLocation($tokens, "tableau_${pcolor}", CARD_STATE_PERMANENT, '', [ 'nod' => true ]);
+            $this->dbSetTokensLocation($tokens, "tableau_${pcolor}", CARD_STATE_PERMANENT, '', ['nod' => true]);
         }
-        
 
-        
-        
+
+
+
         $discardPlayed = $this->getGameStateValue('discard_played');
         if ($discardPlayed) {
             $this->saction_EndOfTurn($player_id);
@@ -3220,11 +3398,11 @@ class EminentDomain extends EuroGame {
             $this->gamestate->nextState('role');
             return;
         }
-        
+
         $logistics = $this->playerHasCard('card_tech_3_86', $color);
         if ($logistics) {
             $actionPlayed = $this->getGameStateValue('action_played');
-            if ($actionPlayed == 0) {// this is good check, if any actions played - action phase was done
+            if ($actionPlayed == 0) { // this is good check, if any actions played - action phase was done
                 $this->dbSetTokenLocation('card_tech_3_86', "tableau_$color", CARD_STATE_PERMANENT_TAPPED, clienttranslate('${player_name} activates ${token_name}'));
                 $this->gamestate->nextState('action');
                 return;
@@ -3241,11 +3419,12 @@ class EminentDomain extends EuroGame {
         $this->gamestate->nextState('next');
     }
 
-    function getUntrivialDiscardOrActivate($color) {
+    function getUntrivialDiscardOrActivate($color)
+    {
         // check if any activatables left
         $tokens = $this->tokens->getTokensOfTypeInLocation("card_tech", "tableau_${color}"); // XXX maybe include planets?
-        foreach ( $tokens as $card => $info ) {
-            if ($this->isPermanentTech($card) && $info ['state'] != CARD_STATE_PERMANENT_TAPPED) {
+        foreach ($tokens as $card => $info) {
+            if ($this->isPermanentTech($card) && $info['state'] != CARD_STATE_PERMANENT_TAPPED) {
                 $rule = $this->getRulesFor($card, 'e');
                 if ($rule) {
                     return 1;
@@ -3260,28 +3439,103 @@ class EminentDomain extends EuroGame {
         return 0;
     }
 
-    function st_gameTurnNextPlayerFollow() {
+    function st_selectScenario()
+    {
+        $scenarios = $this->isScenarioVariant();
+        if (!$scenarios) {
+            $this->gamestate->nextState('last');
+            return;
+        }
+
+        $selectScenarioVariant = $this->isScenarioSelection();
+        if (!$selectScenarioVariant) {
+            $this->tokens->shuffle("scenarios");
+            $players = $this->loadPlayersBasicInfos();
+            foreach ($players as $player_info) {
+                $color = $player_info['player_color'];
+                $this->tokens->pickTokensForLocation(1, "scenarios", "tableau_$color", 1);
+            }
+            $this->gamestate->nextState('last');
+        }
+    }
+
+    function st_scenarioNextPlayer()
+    {
+        $player_id = $this->getActivePlayerId();
+        $next_player_id = $this->getPlayerAfter($player_id);
+        if ($next_player_id === $this->getFirstPlayer()) {
+            $this->gamestate->nextState('last');
+        } else {
+            $this->activeNextPlayer();
+            $this->gamestate->nextState('nextPlayer');
+        }
+    }
+
+    function action_selectScenario($card)
+    {
+        self::checkAction('selectScenario');
+        $player_id = $this->getCurrentPlayerId();
+        $color = $this->getPlayerColor($player_id);
+        // $check card
+        $tokens = $this->tokens->getTokensOfTypeInLocation("scenario", "scenarios");
+        $this->systemAssertTrue("Bad card for pick", array_key_exists($card, $tokens));
+        $this->dbSetTokenLocation($card, "tableau_$color", 1, clienttranslate('${player_name} picked ${token_name}'));
+
+        $sc = $this->tokens->getTokenOfTypeInLocation('scenario', "tableau_$color");
+        $key = $sc['key'];
+
+        // apply the scenario information
+        $this->scenarioProcess();
+
+        $token = $this->token_types[$key];
+        $conflicts = $token['conflict'];
+        // remove conflicting scenarios
+        foreach ($conflicts as $confKey) {
+            // Conflicts will include all expansions, even if not active
+            $tokenExists = $this->tokens->getTokenLocation($confKey) !== null;
+            if ($tokenExists) {
+                $this->dbSetTokenLocation($confKey, 'dev_null', null, clienttranslate('${token_name} can no longer be selected'));
+            }
+        }
+
+        $this->gamestate->nextState('');
+    }
+
+    function st_gamePlayerSetup()
+    {
+        $this->setupPlayers();
+        // begging of the turn for active player
+        $player_id = $this->getActivePlayerId();
+        $this->saction_TurnReplenish($player_id);
+        $this->incStat(1, 'turns_number', $player_id);
+        $this->incStat(1, 'turns_number');
+
+        $this->gamestate->nextState('');
+    }
+
+    function st_gameTurnNextPlayerFollow()
+    {
         $role_index = $this->getGameStateValue('role');
         if ($role_index < 0) {
             // No role was played by the previous player (can happen only if it's a zombie) -> nothing to follow
             $this->gamestate->nextState('last');
             return;
         }
-        $role = $this->materials ['role_icons'] [$role_index];
-        $this->dbSetPlayerMultiactive( -1, 1); // all active
+        $role = $this->materials['role_icons'][$role_index];
+        $this->dbSetPlayerMultiactive(-1, 1); // all active
 
         $leader_id = $this->getGameStateValue('leader');
         $player_id = $this->getPlayerAfter($leader_id);
-        $mactive_players = array ();
-        $waiting = array ();
+        $mactive_players = array();
+        $waiting = array();
         $this->dbSetPlayerMultiactive($leader_id, 0);
         $alwaysWaiting = $this->isAsync() == false; // realtime
-        while ( $player_id != $leader_id ) {
-            if ( !$this->isPlayerMaskSet($player_id, 'followers')) {
-                if ( !$this->autoDissent($player_id, $role)) {
-                    $mactive_players [] = $player_id;
+        while ($player_id != $leader_id) {
+            if (!$this->isPlayerMaskSet($player_id, 'followers')) {
+                if (!$this->autoDissent($player_id, $role)) {
+                    $mactive_players[] = $player_id;
                     $iswaiting = $alwaysWaiting || $this->isPlayerMaskSet($player_id, 'followers_waiting');
-                    $waiting [$player_id] = $iswaiting;
+                    $waiting[$player_id] = $iswaiting;
                 } else {
                     $this->dbSetPlayerMultiactive($player_id, 0);
                 }
@@ -3291,61 +3545,67 @@ class EminentDomain extends EuroGame {
             $player_id = $this->getPlayerAfter($player_id);
         }
         if (count($mactive_players) > 0) {
-            $active_follower = $mactive_players [0];
+            $active_follower = $mactive_players[0];
             $this->setGameStateValue('active_follower', $active_follower);
             $this->clearPlayerMask($active_follower, 'followers_waiting');
-            $waiting [$active_follower] = 0; // active follower cannot wait
-            foreach ( $mactive_players as $cur_player_id ) {
-                if ($waiting [$cur_player_id])
+            $waiting[$active_follower] = 0; // active follower cannot wait
+            foreach ($mactive_players as $cur_player_id) {
+                if ($waiting[$cur_player_id])
                     $this->dbSetPlayerMultiactive($cur_player_id, 0);
                 else
                     $this->giveExtraTime($cur_player_id);
             }
-          
-            if ($this->autoDissent($active_follower,$role)) {
+
+            if ($this->autoDissent($active_follower, $role)) {
                 $this->gamestate->nextState('loopback');
                 return;
             }
         }
-        if ( !$this->gamestate->updateMultiactiveOrNextState('last')) {// last is game upkeep (STATE_GAME_TURN_UPKEEP)
-            $this->setGameStateValue('boost_rem', 0);// reset research boost
-            $this->gamestate->nextState('next');// player follow
+        if (!$this->gamestate->updateMultiactiveOrNextState('last')) { // last is game upkeep (STATE_GAME_TURN_UPKEEP)
+            $this->setGameStateValue('boost_rem', 0); // reset research boost
+            $this->gamestate->nextState('next'); // player follow
         }
     }
 
-    function autoDissent($player_id, $role) {
+    function autoDissent($player_id, $role)
+    {
         $color = $this->getPlayerColor($player_id);
-        if ($this->dbGetPref(150, $color) != 1) {// PREF_AUTO_DISSENT
+        if ($this->dbGetPref(150, $color) != 1) { // PREF_AUTO_DISSENT
             return;
         }
-        if ( !$this->canFollow($player_id, $role)) {
-            $role_name = $this->materials ['icons'] [$role];
-            $role_args = [ 'role_name' => $role_name,'i18n' => [ 'role_name' ] ];
+        if (!$this->canFollow($player_id, $role)) {
+            $role_name = $this->materials['icons'][$role];
+            $role_args = ['role_name' => $role_name, 'i18n' => ['role_name']];
 
-            $this->notifyPlayer($player_id, 'playerLog', 
-                    clienttranslate('[private] game calculated that there is no legitimate way for you to follow ${role_name}'), 
-                    $role_args );
+            $this->notifyPlayer(
+                $player_id,
+                'playerLog',
+                clienttranslate('[private] game calculated that there is no legitimate way for you to follow ${role_name}'),
+                $role_args
+            );
             $this->action_playDissentGame($player_id);
             return true;
         }
         return false;
     }
 
-    function canFollow($player_id, $role) {
+    function canFollow($player_id, $role)
+    {
         $info = $this->arg_playerTurnInfo($player_id, "f-" . $role);
-        return $this->canFollowOnInfo($info, $role,$player_id);
+        return $this->canFollowOnInfo($info, $role, $player_id);
     }
 
-    function canFollowOnInfo($info, $role,$player_id) {
-        $hb = $info ['hand_boost_num'] [$role];
-        $pb = $info ['perm_boost_num'] [$role];
+    function canFollowOnInfo($info, $role, $player_id)
+    {
+        $hb = $info['hand_boost_num'][$role];
+        $pb = $info['perm_boost_num'][$role];
         $total = $hb + $pb;
-        if ($this->playerHasCard('card_tech_E_2', $this->getPlayerColorById($player_id))) {//freedom of trade
+        if ($this->playerHasCard('card_tech_E_2', $this->getPlayerColorById($player_id))) { //freedom of trade
             if ($role == 'P' || $role == 'T') {
                 return true; // do not auto-disscent
             }
         }
-        
+
         if ($total == 0 && $role != 'R')
             return false;
         if ($role == 'C' && $hb == 0)
@@ -3371,22 +3631,23 @@ class EminentDomain extends EuroGame {
      * You can do whatever you want in order to make sure the turn of this player ends appropriately
      * (ex: pass).
      */
-    function zombieTurn($state, $active_player) {
-        $statename = $state ['name'];
-        if ($state ['type'] === "activeplayer") {
+    function zombieTurn($state, $active_player)
+    {
+        $statename = $state['name'];
+        if ($state['type'] === "activeplayer") {
             switch ($statename) {
-                case 'playerTurnAction' :
+                case 'playerTurnAction':
                     $this->gamestate->nextState("last");
                     break;
-                default :
+                default:
                     $this->gamestate->nextState("next");
                     break;
             }
             return;
         }
-        if ($state ['type'] === "multipleactiveplayer") {
+        if ($state['type'] === "multipleactiveplayer") {
             //if ($statename == "playerTurnFollow")
-             $this->setPlayerMask($active_player, 'followers');
+            $this->setPlayerMask($active_player, 'followers');
             // Make sure player is in a non blocking status for role turn
             $this->gamestate->setPlayerNonMultiactive($active_player, 'next');
             return;
@@ -3407,7 +3668,8 @@ class EminentDomain extends EuroGame {
      * update the game database and allow the game to continue to run with your new version.
      *
      */
-    function upgradeTableDb($from_version) {
+    function upgradeTableDb($from_version)
+    {
         // $from_version is the current version of this game database, in numerical form.
         // For example, if the game was running with a release of your game named "140430-1345",
         // $from_version is equal to 1404301345

--- a/eminentdomain.js
+++ b/eminentdomain.js
@@ -15,10 +15,10 @@
 var SYM_RIGHTARROW = " &rarr; ";
 define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 	// load my own module!!!
-	g_gamethemeurl + "modules/sharedparent.js"], function(dojo, declare) {
+	g_gamethemeurl + "modules/sharedparent.js"], function (dojo, declare) {
 		return declare("bgagame.eminentdomain", bgagame.sharedparent, // parent declared in shared module
 			{
-				constructor: function() {
+				constructor: function () {
 					console.log('eminentdomain constructor');
 					g_img_preload = ['cards.jpg', 'board.jpg', 'planets.jpg'];
 
@@ -37,7 +37,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				 * 
 				 * "gamedatas" argument contains all datas retrieved by your "getAllDatas" PHP method.
 				 */
-				setup: function(gamedatas) {
+				setup: function (gamedatas) {
 					console.log("Starting game setup", gamedatas);
 					//   dojo.destroy('debug_output');
 					this.inSetup = true;
@@ -55,18 +55,18 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 
 					this.updateEndOfGameMessage(gamedatas);
-	
+
 
 					if (!this.isReadOnly()) {
 						this.checkPreferencesConsistency(this.gamedatas.server_prefs);
 					}
-					
+
 					this.setupPreference();
 
 					console.log("Ending game setup");
 				},
-				
-				checkPreferencesConsistency: function(backPrefs) {
+
+				checkPreferencesConsistency: function (backPrefs) {
 					//console.log('check pref',backPrefs,this.prefs);
 					for (var key in backPrefs) {
 						let value = backPrefs[key];
@@ -76,12 +76,12 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							var args = { pref: pref, value: user_value, player: this.player_id };
 							backPrefs[key] = user_value;
 							this.ajaxcall("/" + this.game_name + "/" + this.game_name + "/" + 'changePreference' + ".html", args,// 
-								this, () => {}, (err, res) => { if (err) console.error("changePreference callback failed " + res); else console.log("changePreference sent " + pref + "=" + user_value); });
+								this, () => { }, (err, res) => { if (err) console.error("changePreference callback failed " + res); else console.log("changePreference sent " + pref + "=" + user_value); });
 
 						}
 					}
 				},
-				setupPreference: function() {
+				setupPreference: function () {
 					// Extract the ID and value from the UI control
 					var _this = this;
 					function onchange(e) {
@@ -101,7 +101,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					dojo.query("#ingame_menu_content .preference_control").forEach((el) => onchange({ target: el }));
 				},
 
-				onPreferenceChange: function(prefId, prefValue) {
+				onPreferenceChange: function (prefId, prefValue) {
 					console.log("Preference changed", prefId, prefValue);
 
 					if (!this.isReadOnly()) {
@@ -110,7 +110,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				},
 
 
-				updateEndOfGameMessage: function(args) {
+				updateEndOfGameMessage: function (args) {
 					var endmessage = _('End of game is triggered.');
 					endmessage += " ";
 					if (this.gamedatas.variants.extra_turn_variant_on) {
@@ -138,7 +138,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 				},
 
-				setupGameTokens: function() {
+				setupGameTokens: function () {
 					if (!this.isSpectator) {
 						this.drawHandIcon(5, 'hand_icon', this.player_color, -2);
 					}
@@ -151,17 +151,17 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						}
 						this.placeTokenWithTips(token);
 					}
-					dojo.query(".counter,.slot_tooltip").forEach(dojo.hitch(this, function(node) {
+					dojo.query(".counter,.slot_tooltip").forEach(dojo.hitch(this, function (node) {
 						this.updateTooltip(node.id);
 					}));
 					this.connectClass('card_bottom', 'onclick', 'onCard');
 					this.connectClass('supply_tech', 'onclick', 'onCard');
 					this.connectClass('discard', 'onclick', 'onDiscard');
 					this.connect($('discard_planets'), 'onclick', 'onDiscard');
-					
-					                    // Labels
-                    $('deck_display').setAttribute('data-title', _('Deck'));
-                    $('discard_display').setAttribute('data-title', _('Discard'));
+
+					// Labels
+					$('deck_display').setAttribute('data-title', _('Deck'));
+					$('discard_display').setAttribute('data-title', _('Discard'));
 
 					this.connectClass('gslider', 'oninput', 'onSlider');
 					this.connectClass('gcheckbox', 'oninput', 'onCheckbox');
@@ -169,7 +169,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					console.log("enging token setup");
 					//dojo.place(this.getJemImg('green'),'bboard');
 				},
-				setupPlayer: function(player_id, playerInfo) {
+				setupPlayer: function (player_id, playerInfo) {
 					// console.log("player info " + player_id, playerInfo);
 					var color = playerInfo.color;
 					var playerBoardDiv = dojo.byId('player_board_' + player_id);
@@ -187,14 +187,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						dojo.connect($('deck_' + color), "onclick", this, "onDeck");
 						dojo.style($('deck_' + color), 'cursor', 'pointer');
 					}
-					$('setaside_'+color).setAttribute('data-title', _('Set Aside Zone'));
+					$('setaside_' + color).setAttribute('data-title', _('Set Aside Zone'));
 				},
 				// /////////////////////////////////////////////////
 				// // Game & client states
 				// onEnteringState: this method is called each time we are entering into a new game state.
 				// You can use this method to perform some user interface changes at this moment.
 				//
-				onEnteringState: function(stateName, args) {
+				onEnteringState: function (stateName, args) {
 					console.log('Entering state: ' + stateName, args);
 
 					this.curstate = stateName;
@@ -212,6 +212,17 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						}
 
 						switch (stateName) {
+							case 'scenarioSelection':
+								this.clientStateArgs.action = 'selectScenario';
+								if (this.isCurrentPlayerActive()) {
+									this.expandScenario();
+								} else {
+									this.hideScenario();
+								}
+								break;
+							case 'gamePlayerSetup':
+								location.reload();
+								break;
 							case 'playerTurnAction':
 								this.clientStateArgs.action = 'playAction';
 								var color = this.getPlayerColor(this.getActivePlayerId());
@@ -227,8 +238,6 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 								break;
 							case 'playerTurnRole':
-
-
 								this.clientStateArgs.action = 'playRole';
 								var color = this.getPlayerColor(this.getActivePlayerId());
 								this.updatePermCounters(color, args.args.perm_boost_num);
@@ -248,7 +257,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								this.clientStateArgs.action = 'playPick';
 								break;
 							case 'playerTurnRoleExtra':
-							    if (!this.isCurrentPlayerActive())
+								if (!this.isCurrentPlayerActive())
 									break;
 								this.clientStateArgs.action = 'playExtra';
 								if (this.instantaneousMode) {
@@ -280,7 +289,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								if (args.args.survey) { //survey select card
 									this.clientStateArgs.action = 'playPick';
 									this.clientStateArgs.nocancel = true;
-									this.setClientStateAction('client_playerTurnSurvey',this.gamedatas.gamestate.descriptionmyturn, 0);
+									this.setClientStateAction('client_playerTurnSurvey', this.gamedatas.gamestate.descriptionmyturn, 0);
 									break;
 								}
 
@@ -321,7 +330,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				// onLeavingState: this method is called each time we are leaving a game state.
 				// You can use this method to perform some user interface changes at this moment.
 				//
-				onLeavingState: function(stateName) {
+				onLeavingState: function (stateName) {
 					console.log('Leaving state: ' + stateName);
 					//console.log('-- cargs: ' + stateName,  this.clientStateArgs);
 					dojo.query(".active_slot").removeClass('active_slot');
@@ -332,24 +341,24 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					//this.expandTech(false);
 				},
 
-				onUpdateActionButtons_playerTurnRole: function(args) {
+				onUpdateActionButtons_playerTurnRole: function (args) {
 					dojo.query(".board  .card_role:last-child").addClass('active_slot');
 					dojo.query(".tableau_" + this.player_color + " .tech.state_1.activatable").addClass('active_slot');
-					this.addImageActionButton('button_warfare', this.createDiv("icon warfare role"), dojo.hitch(this, function() {
+					this.addImageActionButton('button_warfare', this.createDiv("icon warfare role"), dojo.hitch(this, function () {
 						this.clientStateArgs.role = 'W';
 						this.clientStateArgs.card = this.getRoleCard('warfare');
 						if (!this.clientStateArgs.card.startsWith("x_"))
 							this.placeTokenLocal(this.clientStateArgs.card, 'setaside_' + this.player_color, 12);
 						this.setClientStateAction('client_selectBoostOrLeader');
 					}));
-					this.addImageActionButton('button_colonize', this.createDiv("icon colonize role"), dojo.hitch(this, function() {
+					this.addImageActionButton('button_colonize', this.createDiv("icon colonize role"), dojo.hitch(this, function () {
 						this.clientStateArgs.role = 'C';
 						this.clientStateArgs.card = this.getRoleCard('colonize');
 						if (!this.clientStateArgs.card.startsWith("x_"))
 							this.placeTokenLocal(this.clientStateArgs.card, 'setaside_' + this.player_color, 12);
 						this.setClientStateAction('client_selectBoostOrLeader');
 					}));
-					this.addImageActionButton('button_survey', this.createDiv("icon survey role"), dojo.hitch(this, function() {
+					this.addImageActionButton('button_survey', this.createDiv("icon survey role"), dojo.hitch(this, function () {
 						this.clientStateArgs.role = 'S';
 						this.clientStateArgs.card = this.getRoleCard('survey');
 						if (!this.clientStateArgs.card.startsWith("x_"))
@@ -357,7 +366,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						this.setClientStateAction('client_selectBoost');
 					}));
 					if (!this.gamedatas.variants.learning_variant_on) {
-						this.addImageActionButton('button_research', this.createDiv("icon research role"), dojo.hitch(this, function() {
+						this.addImageActionButton('button_research', this.createDiv("icon research role"), dojo.hitch(this, function () {
 							this.clientStateArgs.role = 'R';
 							this.clientStateArgs.card = this.getRoleCard('research');
 							if (!this.clientStateArgs.card.startsWith("x_"))
@@ -365,14 +374,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							this.setClientStateAction('client_selectBoost');
 						}));
 					}
-					this.addImageActionButton('button_produce', this.createDiv("icon produce role"), dojo.hitch(this, function() {
+					this.addImageActionButton('button_produce', this.createDiv("icon produce role"), dojo.hitch(this, function () {
 						this.clientStateArgs.role = 'P';
 						this.clientStateArgs.card = this.getRoleCard('produce');
 						if (!this.clientStateArgs.card.startsWith("x_"))
 							this.placeTokenLocal(this.clientStateArgs.card, 'setaside_' + this.player_color, 12);
 						this.setClientStateAction('client_selectBoost');
 					}));
-					this.addImageActionButton('button_trade', this.createDiv("icon trade role"), dojo.hitch(this, function() {
+					this.addImageActionButton('button_trade', this.createDiv("icon trade role"), dojo.hitch(this, function () {
 						this.clientStateArgs.role = 'T';
 						this.clientStateArgs.card = this.getRoleCard('produce');
 						if (!this.clientStateArgs.card.startsWith("x_"))
@@ -385,7 +394,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				// onUpdateActionButtons: in this method you can manage "action buttons" that are displayed in the
 				// action status bar (ie: the HTML links in the status bar).
 				//        
-				onUpdateActionButtons: function(stateName, args) {
+				onUpdateActionButtons: function (stateName, args) {
 					//console.log('onUpdateActionButtons: ' + stateName, args);
 					if (this.curstate != stateName) {		// delay firing this
 						this.pendingUpdate = true;
@@ -441,9 +450,9 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								};
 								if (stateName == 'playerTurnPreDiscard') {
 									this.addActionButton('button_wait', _("Wait"), () => this.ajaxClientStateAction('playWait'));
-									this.addTooltip('button_wait', 
-									     _("Now you can discard cards instead of waiting until end of turn. If you do your turn will end automatically."),
-										 _("Click Wait to skip discarding now and do it after after player done following"), 1000);
+									this.addTooltip('button_wait',
+										_("Now you can discard cards instead of waiting until end of turn. If you do your turn will end automatically."),
+										_("Click Wait to skip discarding now and do it after after player done following"), 1000);
 								}
 
 								break;
@@ -453,7 +462,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								dojo.query(".hand > .card_planet").addClass('active_slot');
 								break;
 							case 'playerTurnGameEnd':
-								this.addActionButton('button_skip', _("End Game"), dojo.hitch(this, function() {
+								this.addActionButton('button_skip', _("End Game"), dojo.hitch(this, function () {
 									this.ajaxClientStateAction('skipAction');
 								}));
 								break;
@@ -489,7 +498,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 											as_role = 'P';
 										}
 										if (as_role) {
-									
+
 											var div = this.createDiv("icon role " + as_role);
 											this.addImageActionButton('button_follow2', _("Follow as ") + " " + div, () => {
 												this.clientStateArgs.role = as_role;
@@ -509,17 +518,17 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 										this.ajaxClientStateAction('playWait');
 									}, 'red', tip);
 								}
-								this.addActionButton('button_dissent', _("Dissent"), dojo.hitch(this, function() {
+								this.addActionButton('button_dissent', _("Dissent"), dojo.hitch(this, function () {
 									this.ajaxClientStateAction('playDissent');
 								}));
 								if (this.prefs[150].value == 2) { // auto dissent with timer
 									if (args.pinfo[this.player_id].can_follow == false) {
-										var timeout = parseInt( Math.random()*10)+10; 
+										var timeout = parseInt(Math.random() * 10) + 10;
 										this.addButtonTimer('button_dissent', undefined, timeout);
 									}
 								}
 								if (args.active_follower != this.player_id) {
-									this.addActionButton('button_wait', _("Wait"), dojo.hitch(this, function() {
+									this.addActionButton('button_wait', _("Wait"), dojo.hitch(this, function () {
 										this.ajaxClientStateAction('playWait');
 									}));
 
@@ -537,7 +546,6 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								break;
 							case 'client_selectCardToRemove':
 								dojo.query(".hand > .card").addClass('active_slot');
-								
 								this.addDoneButton();
 
 								var rules = this.clientStateArgs.unprocessed_choices.replace("!", "");
@@ -549,14 +557,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 									this.setDescriptionOnMyTurn(_('Select up to ${total} card(s) to remove from the game'), {
 										total: total
 									});
-									if (!dojo.hasClass(this.clientStateArgs.card, 'toremove') && 
+									if (!dojo.hasClass(this.clientStateArgs.card, 'toremove') &&
 										!dojo.hasClass(this.clientStateArgs.card, 'permanent') &&
 										!dojo.hasClass(this.clientStateArgs.card, 'planet')) {
-											dojo.addClass(this.clientStateArgs.card, 'active_slot');
-											this.addActionButton('button_self', _("Remove Itself"), dojo.hitch(this, function() {
-												dojo.addClass(this.clientStateArgs.card, 'toremove');
-												this.commitOperationAndSubmit('e', this.clientStateArgs.card);
-											}));
+										dojo.addClass(this.clientStateArgs.card, 'active_slot');
+										this.addActionButton('button_self', _("Remove Itself"), dojo.hitch(this, function () {
+											dojo.addClass(this.clientStateArgs.card, 'toremove');
+											this.commitOperationAndSubmit('e', this.clientStateArgs.card);
+										}));
 									}
 								} else if (rules[0] == 'E') {
 									this.setDescriptionOnMyTurn(_('Select any number of cards to remove from the game'), {
@@ -588,7 +596,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								break;
 							case 'client_selectResourceToTrade':
 								// resource on planet and cards
-								var ress=dojo.query(".tableau_" + this.player_color + " .resource.state_2");
+								var ress = dojo.query(".tableau_" + this.player_color + " .resource.state_2");
 								ress.addClass('active_slot');
 
 								// weapon emporium
@@ -604,7 +612,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								this.setDescriptionOnMyTurn(_('Select a resource to trade: ${boost_count} left'), {
 									boost_count: this.clientStateArgs.unprocessed_choices.length
 								});
-								
+
 								if (ress.length > 0)
 									this.addActionButton('random', _('All Random'), () => {
 										// produce on random planets
@@ -622,7 +630,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 										}
 										this.actionPromptAndCommit();
 									});
-								
+
 
 								this.addDoneButton();
 								break;
@@ -698,16 +706,16 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								if (this.clientStateArgs.action == 'playAction') {
 									var rule = this.clientStateArgs.unprocessed_choices[0];
 									var message = _('${You} may select planet to settle or add colonies');
-								
+
 									switch (rule) {
 										//.
 										case 's': // settle or +1 colony
 											this.addActionButton('button_settle', _("Settle 1 Planet"), dojo.hitch(this,
-												function() {
+												function () {
 													this.setClientStateAction('client_selectFaceDownPlanetSettleOnly');
 												}));
 											this.addImageActionButton('button_colony', _("+1 Colony ") + this.createDiv("icon colonize"), dojo.hitch(this,
-												function() {
+												function () {
 													this.clientStateArgs.unprocessed_choices = "c";
 													this.setClientStateAction('client_selectFaceDownPlanetColonize',
 														_('Select a planet to add a colony'));
@@ -716,7 +724,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 										case 'S':// settle or skip
 											var message = _('${You} may select planet to settle or skip');
 											this.addActionButton('button_skip', _("Skip Settle"), dojo.hitch(this,
-												function() {
+												function () {
 													this.commitOperationAndSubmit('S', "skip");
 												}));
 											break;
@@ -735,7 +743,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								if (this.gamedatas.gamestate.args.extra) {
 									totalResearch = args.boost_rem;
 								}
-								
+
 								var techs = this.gamedatas.gamestate.args.tech;
 								var settledTypes = 0;
 
@@ -772,6 +780,11 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 								} else {
 									this.expandTech(true, ".tech.active_slot:not(.fleet_basic)", "selection_area");
+									this.addActionButton('button_skip', _('Forfeit Technology card, gain Role card only'), (e) => {
+										this.clientStateArgs.choices.push(['x']);
+										this.ajaxClientStateAction();
+										this.expandTech(false);
+									});
 								}
 								if (this.gamedatas.gamestate.args.extra) {
 									this.setMainTitle(this.getTokenName(this.gamedatas.gamestate.args.card) + ":", 'before');
@@ -797,14 +810,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								switch (laction) {
 									case 'a':
 									case 'W':
-										this.addActionButton('button_attack', "<span class='yellow'>Leader:</span> Attack 1 Planet", dojo.hitch(this, function() {
+										this.addActionButton('button_attack', "<span class='yellow'>Leader:</span> Attack 1 Planet", dojo.hitch(this, function () {
 											this.clientStateArgs.unprocessed_choices = 'a';
 											this.setClientStateAction('client_selectActionAttack');
 										}));
 										break;
 									case 's':
 									case 'C':
-										this.addActionButton('button_settle', "<span class='yellow'>Leader:</span> Settle 1 Planet", dojo.hitch(this, function() {
+										this.addActionButton('button_settle', "<span class='yellow'>Leader:</span> Settle 1 Planet", dojo.hitch(this, function () {
 											this.clientStateArgs.unprocessed_choices = 's';
 											this.setClientStateAction('client_selectFaceDownPlanetSettleOnly');
 										}));
@@ -813,11 +826,11 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 										if (info != null && info.r == 'P/T') {
 											this.setDescriptionOnMyTurn(_('${You} must select between produce and trade'));
 											this.addImageActionButton('button_produce', this.createDiv("icon produce"), dojo.hitch(this,
-												function() {
+												function () {
 													this.clientStateArgs.role = 'P';
 													this.setClientStateAction('client_selectBoost');
 												}));
-											this.addImageActionButton('button_trade', this.createDiv("icon trade"), dojo.hitch(this, function() {
+											this.addImageActionButton('button_trade', this.createDiv("icon trade"), dojo.hitch(this, function () {
 												this.clientStateArgs.role = 'T';
 												this.setClientStateAction('client_selectBoost');
 											}));
@@ -872,15 +885,15 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 									messagex = '${icon}${icon}${icon}';
 								else if (total == 4)
 									messagex = '${icon}${icon}${icon}${icon}';
-								if (possible_boost) 
-									messagex += ' '+('(unused boost ${remaining_boost})');
-					
+								if (possible_boost)
+									messagex += ' ' + ('(unused boost ${remaining_boost})');
+
 								var icondiv = this.format_string_recursive(messagex, {
 									icon: this.createDiv("icon " + this.clientStateArgs.role),
 									total: total,
 									remaining_boost: possible_boost
 								});
-								args.possible_boost=possible_boost;
+								args.possible_boost = possible_boost;
 								if (this.clientStateArgs.role == 'S') {
 									var thorough_survery = this.playerHasOnTableau('card_tech_E_24')
 									var lookup = total - 1;
@@ -889,20 +902,20 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 
 									if (thorough_survery && lookup - 2 >= 2) {
-										var div = _("Execute with Thorough Survey ") + " " +  icondiv;
+										var div = _("Execute with Thorough Survey ") + " " + icondiv;
 										var but = this.addImageActionButton('button_done_' + total + "_ts", div, 'onExecuteRole', 'blue');
-									    var ll=lookup-2;
+										var ll = lookup - 2;
 										this.addTooltip(but.id, _('Draw') + " " + ll + " - " + _('Keep 2'), '', 1000);
 									}
-									var div = _("Execute Role ") + " " +  icondiv;
+									var div = _("Execute Role ") + " " + icondiv;
 									var col = 'blue';
 									if (lookup <= 0) col = 'red';
 									var but = this.addImageActionButton('button_done_' + total, div, 'onExecuteRole', col);
-									this.addTooltip(but, _('Draw') + " " + lookup + " - "+_('Keep 1'), '',1000);
-					
+									this.addTooltip(but, _('Draw') + " " + lookup + " - " + _('Keep 1'), '', 1000);
+
 
 								} else if (this.clientStateArgs.role != 'P/T') {
-									var div = _("Execute Role ") + " " +  icondiv;
+									var div = _("Execute Role ") + " " + icondiv;
 									this.addImageActionButton('button_done_' + total, div, 'onExecuteRole', 'blue');
 								}
 								break;
@@ -949,7 +962,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				 * Here, you can defines some utility methods that you can use everywhere in your javascript script.
 				 * 
 				 */
-				getPlaceRedirect: function(token, tokenInfo) {
+				getPlaceRedirect: function (token, tokenInfo) {
 					if (!tokenInfo) {
 						return {
 							location: 'dev_null',
@@ -977,14 +990,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					} else if (location.startsWith('tableau') && token.startsWith('card')) {
 						// result.location = token + "_group";
 						result.createOn = location;
-						
-						var color=getPart(location,1);
-						var sep='';
+
+						var color = getPart(location, 1);
+						var sep = '';
 						if (token.startsWith('scenario')) {
-							 sep = "sep_scenario_"+color;
+							sep = "sep_scenario_" + color;
 						} else {
 							var cardtype = getPart(token, 1);
-							if (cardtype == 'planet' ) {
+							if (cardtype == 'planet') {
 								if (tokenInfo.state == 0)
 									cardtype += '0';
 								else {
@@ -1002,7 +1015,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						}
 					} else if (location.startsWith('tableau') && token.startsWith('fighter')) {
 						var type = getPart(token, 1);
-						if (type=='j1') type='F';
+						if (type == 'j1') type = 'F';
 						result.location = 'tableau_fighter_' + type + "_" + getPart(location, 1);
 						result.createOn = 'stock_fighter';
 					} else if (token.startsWith('scenario')) {
@@ -1047,20 +1060,20 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return result;
 				},
-				getJemImg: function(colorId) {
+				getJemImg: function (colorId) {
 					var jem = "<img class='imgtext' src='" + g_themeurl + "img/mainsite/status-" + colorId + ".png' alt='" + colorId + "' />";
 					return jem;
 				},
 				/** @override */
-				change3d: function(xaxis, xpos, ypos, zaxis, scale, enable3d, clear3d) {
+				change3d: function (xaxis, xpos, ypos, zaxis, scale, enable3d, clear3d) {
 					this.inherited(arguments);
 					this.adjust3D();
 				},
-				adjust3D: function(e) {
+				adjust3D: function (e) {
 					if (this.isSpectator) return;
 					var hand = 'hand_area';
 
-					setTimeout(dojo.hitch(this, function() {
+					setTimeout(dojo.hitch(this, function () {
 						var control3dmode3d = this.control3dmode3d;
 						//console.log("3d mode: " + control3dmode3d);
 						if (control3dmode3d) {
@@ -1078,7 +1091,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				 * @param {*} player_color 
 				 * @param {*} off 
 				 */
-				drawHandIcon: function(num, place, player_color, off) {
+				drawHandIcon: function (num, place, player_color, off) {
 					if (typeof off == 'undefined') off = -1;
 					for (var i = 0; i < num; i++) {
 						var deg = (i + off) * 20;
@@ -1086,13 +1099,13 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							';transform-origin: bottom center;transform: rotate(' + deg + 'deg)"></div>', place);
 					}
 				},
-				cancelLocalStateEffects: function() {
+				cancelLocalStateEffects: function () {
 					this.inherited(arguments);
 					this.expandTech(false);
 					dojo.query('.claimed').removeClass('claimed');
 					dojo.query('.thething .expanded').removeClass('expanded');
 				},
-				setClientStateCustom: function(state, descr, args, onHandlers) {
+				setClientStateCustom: function (state, descr, args, onHandlers) {
 
 					if (onHandlers) {
 						for (var met in onHandlers) {
@@ -1103,7 +1116,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					this.setClientStateAction(state, descr, 0, args);
 				},
 
-				shuffleArray: function(array) {
+				shuffleArray: function (array) {
 					//https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
 					for (let i = array.length - 1; i > 0; i--) {
 						const j = Math.floor(Math.random() * (i + 1));
@@ -1112,7 +1125,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				},
 
 				/** @Override */
-				format_string_recursive: function(log, args) {
+				format_string_recursive: function (log, args) {
 					try {
 						//console.trace("format_string_recursive(" + log + ")", args);
 						if (args.log_others !== undefined && this.player_id != args.player_id) {
@@ -1135,7 +1148,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								if (typeof args[key] != 'undefined') {
 									if (key == 'token_divs' || key == 'token_div') {
 										var list = args[key].split(",");
-											var res = "";
+										var res = "";
 										for (var l = 0; l < list.length; l++) {
 											var name = this.getTokenDivForLogValue('token_div', list[l]);
 											res += name + " ";
@@ -1170,10 +1183,10 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return this.inherited(arguments);
 				},
-				getTokenDivForLogValue: function(key, value) {
+				getTokenDivForLogValue: function (key, value) {
 					// ... implement whatever html you want here
 					var token_id = value;
-					if (value===undefined) {
+					if (value === undefined) {
 						console.trace(key);
 					}
 					if (token_id == null) { return "? " + key; }
@@ -1198,7 +1211,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return this.divInlineToken(token_id);
 				},
-				updateDisplayInfo: function(info) {
+				updateDisplayInfo: function (info) {
 					var tt = getFirstParts(info.key, 2);
 					//					console.log(tt, info.tokenKey);
 					switch (tt) {
@@ -1221,7 +1234,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								args.icons = this.getTr('None');
 							}
 
-							var resources = info.slots ? info.slots: '';
+							var resources = info.slots ? info.slots : '';
 							if (resources) {
 								resource_names = [];
 								for (j = 0; j < resources.length; j++) {
@@ -1289,7 +1302,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 							// add icons for html
 							var cost = info['b']; // research cost
-							var icons = info.i ? info.i: ''; // icons
+							var icons = info.i ? info.i : ''; // icons
 							if (info.h)
 								icons += 'h';
 
@@ -1365,10 +1378,10 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								info.tooltip += " ";
 								var flip = info.flip;
 								var reverseInfo = this.gamedatas.token_types[flip];
-								info.tooltip += this.getTr(reverseInfo.name); 
+								info.tooltip += this.getTr(reverseInfo.name);
 								info.tooltip += "<br>";
 								// add type
-								info.type += " side_"+info.side;
+								info.type += " side_" + info.side;
 							}
 
 							break;
@@ -1378,7 +1391,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								info.tooltip += this.createSpanHtml(_('Reverse Side:'), 'yellow');
 								info.tooltip += "<br>";
 								var reverseInfo = this.getTokenDisplayInfo('card_fleet_i');
-								info.tooltip += this.getTr(reverseInfo.name); 
+								info.tooltip += this.getTr(reverseInfo.name);
 								info.tooltip += "<p>";
 								info.tooltip += this.getTr(reverseInfo.tooltip);
 							}
@@ -1397,7 +1410,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						info.tooltip += "</i>";
 					}
 				},
-				getTooptipHtmlForTokenInfo: function(tokenInfo) {
+				getTooptipHtmlForTokenInfo: function (tokenInfo) {
 					var main = this.getTooptipHtml(tokenInfo.name, tokenInfo.tooltip, tokenInfo.imageTypes, "<hr/>");
 					var token = tokenInfo.tokenKey;
 					// see also updateDisplayInfo where main tooltip build is going
@@ -1421,7 +1434,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return main;
 				},
-				showPlanetBackTooltip: function(token) {
+				showPlanetBackTooltip: function (token) {
 					var node = $(token);
 					var parentNode = node.parentNode;
 					if (dojo.hasClass(node, "state_0")) {
@@ -1430,7 +1443,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return false;
 				},
-				strRepeat: function(comm, multiplier) {
+				strRepeat: function (comm, multiplier) {
 					if (multiplier === undefined)
 						multiplier = 1;
 					if (multiplier == 1) return comm;
@@ -1440,7 +1453,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return res;
 				},
-				prependOperation: function(comm, multiplier) {
+				prependOperation: function (comm, multiplier) {
 					var rules = this.strRepeat(comm, multiplier);
 					var subrules = rules.split('/');
 					if (subrules.length <= 1) {
@@ -1457,7 +1470,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					return this.clientStateArgs.unprocessed_choices;
 				},
 
-				consumeOperation: function(op) {
+				consumeOperation: function (op) {
 					var rules = this.clientStateArgs.unprocessed_choices;
 					if (!rules) return false;
 					var subrules = rules.split('/');
@@ -1474,7 +1487,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					this.clientStateArgs.unprocessed_choices = subrules_new.join("/");
 					return true;
 				},
-				commitOperation: function(ops, id, extra1, extra2) {
+				commitOperation: function (ops, id, extra1, extra2) {
 					if (id === undefined)
 						id = 'x';
 					var operation = [ops, id];
@@ -1497,7 +1510,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					return false;
 				},
 
-				commitOperationAndSubmit: function(ops, id, extra, animation_handler) {
+				commitOperationAndSubmit: function (ops, id, extra, animation_handler) {
 					if (this.commitOperation(ops, id, extra)) {
 						if (animation_handler !== undefined)
 							animation_handler();
@@ -1506,7 +1519,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return false;
 				},
-				commitOperationAndAction: function(ops, id, extra, animation_handler) {
+				commitOperationAndAction: function (ops, id, extra, animation_handler) {
 					if (this.commitOperation(ops, id, extra)) {
 						if (animation_handler !== undefined)
 							animation_handler();
@@ -1514,24 +1527,24 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return false;
 				},
-				showMoveUnauthorized: function() {
+				showMoveUnauthorized: function () {
 					console.error("This move is not authorized now");
 					console.trace("trace");
 					this.showMessage(__("lang_mainsite", "This move is not authorized now"), "error");
 				},
-				addCancelButton: function() {
+				addCancelButton: function () {
 					if (!$('button_cancel')) {
 						this.addActionButton('button_cancel', _('Cancel'), () => this.cancelLocalStateEffects(), null, null, 'red');
 					}
 				},
-				addDoneButton: function(text) {
+				addDoneButton: function (text) {
 					if ($('button_done')) {
 						dojo.destroy('button_done');
 					}
 					if (typeof text == 'undefined') text = _("Done");
 					var cs = this.clientStateArgs.unprocessed_choices;
 
-					this.addActionButton('button_done', text, dojo.hitch(this, function() {
+					this.addActionButton('button_done', text, dojo.hitch(this, function () {
 						var command = this.clientStateArgs.unprocessed_choices[0];
 						if (command == '!' || command == '>' || !command) {
 							this.ajaxClientStateAction();
@@ -1549,7 +1562,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						dojo.addClass('button_done', 'blinking');
 					}
 				},
-				zeroBoostPrompt: function(leader) {
+				zeroBoostPrompt: function (leader) {
 					var message;
 					if (leader) message = _('You have no boost or not enough boost, this will only gain you a role card. Proceed?');
 					else message = _('You have no boost or not enough boost, that will be no-op. Proceed?');
@@ -1558,11 +1571,11 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						() => this.ajaxClientStateAction()
 					);
 				},
-				createDivFromInfo: function(type, id, extra, classes) {
+				createDivFromInfo: function (type, id, extra, classes) {
 					var info = this.getTokenDisplayInfo(type);
-					return this.createDiv(info.imageTypes + " " + (classes ? classes: ''), id, extra);
+					return this.createDiv(info.imageTypes + " " + (classes ? classes : ''), id, extra);
 				},
-				createActionVisuals: function(rules) {
+				createActionVisuals: function (rules) {
 					var res = "";
 					for (var i = 0; i < rules.length; i++) {
 						var command = rules[i];
@@ -1613,7 +1626,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return res;
 				},
-				canPay: function(action_rules) {
+				canPay: function (action_rules) {
 					var reqs = action_rules.split('>', 2);
 					if (reqs.length > 1) {
 						var paycost = reqs[0];
@@ -1623,7 +1636,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return true;
 				},
-				payAll: function(rules) {
+				payAll: function (rules) {
 					var same = 1;
 					for (var i = 0; i < rules.length; i++) {
 						var command = rules[i];
@@ -1640,7 +1653,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return rules.length;
 				},
-				payOne: function(rule, showError, num) {
+				payOne: function (rule, showError, num) {
 					if (!num) num = 1;
 					var querys;
 					var queryc;
@@ -1663,7 +1676,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						case 'F':
 						case 'D':
 						case 'B':
-				
+
 							var querys = this.queryIds("#tableau_fighter_" + rule + "_" + this.player_color + " > *:not(.claimed)");
 							var queryc = this.queryIds("#hand_" + this.player_color + " > .as_fighter_" + rule + ":not(.claimed)");
 							var queryr = this.queryIds("#tableau_" + this.player_color + " > .has_rslots > .fighter_" + rule + ":not(.claimed)");
@@ -1674,8 +1687,8 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								if (icons)
 									hand_icons_count += (icons.split(rule).length - 1);
 							}
-							
-				
+
+
 							var total = querys.length + hand_icons_count + queryr.length;
 							if (!showError) {
 								return total >= num;
@@ -1685,7 +1698,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								return null;
 							}
 							var custom = queryc.length;
-						
+
 
 							var res = queryc;
 							if (queryr.length >= 1) {
@@ -1694,7 +1707,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								res.push(querys[0]);
 							}
 							//console.log("pay rule select", res);
-							
+
 							if (res.length == 1 && custom == 0) {
 								var payment = res[0];
 								dojo.addClass(payment, 'claimed');
@@ -1708,23 +1721,23 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 
 				},
-				playerHasOnTableau: function(card, state) {
+				playerHasOnTableau: function (card, state) {
 					if (state !== undefined) {
 						if (dojo.hasClass(card, "state_" + state))
 							return false;
 					}
 					return this.getFirstChild(".tableau_" + this.player_color + "> #" + card);
 				},
-				playerHas: function(query) {
+				playerHas: function (query) {
 					return this.getFirstChild(".tableau_" + this.player_color + "> " + query);
 				},
-				getFirstChild: function(q, x) {
+				getFirstChild: function (q, x) {
 					var res = dojo.query(q);
 					if (res.length == 0) return x;
 					return res[0].id;
 				},
 
-				ajaxClientStateAction: function(action) {
+				ajaxClientStateAction: function (action) {
 					// massage data
 					delete this.clientStateArgs.unprocessed_choices;
 					this.clientStateArgs.choices_js = JSON.stringify(this.clientStateArgs.choices),
@@ -1732,14 +1745,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					this.inherited(arguments);
 				},
 
-				actionPromptAndCommit: function() {
+				actionPromptAndCommit: function () {
 					var auto = this.actionPrompt();
 					if (auto) {
 						this.ajaxClientStateAction();
 					}
 					return false;
 				},
-				actionPrompt: function() {
+				actionPrompt: function () {
 					//debugger;
 					if (this.clientStateArgs.unprocessed_choices === undefined) {
 						this.showError("Bad state - no action");
@@ -1753,8 +1766,8 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					if (subactions.length > 1) {
 						// multiple choice
 						dojo.empty('generalactions');
-						
-					
+
+
 						var pay = false;
 						for (var i = 0; i < subactions.length; i++) {
 							var sub = subactions[i];
@@ -1792,9 +1805,9 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							this.addCancelButton();
 
 						return false;
-					} 
-						
-					
+					}
+
+
 					this.clientStateArgs.actnum = 0;
 
 					var reqs = rules.split('>', 2);
@@ -1804,7 +1817,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 					var command = this.clientStateArgs.unprocessed_choices[0];
 					var lookup = this.clientStateArgs.unprocessed_choices[1];
-					
+
 					switch (command) {
 						case 'l': // polictics
 							this.setClientStateAction('client_selectRoleCard', _('Select a role card to gain'));
@@ -1888,7 +1901,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							if ($(mydeck_counter).innerHTML == 0) {
 								mydeck = "discard_" + this.player_color;
 							}
-									
+
 							this.setClientStateCustom('client_reconDeck', _('RECON your Deck (select a top card)'), [], {
 								onUpdateActionButtons: (args) => {
 									this.revealLocation(mydeck, true);
@@ -1906,7 +1919,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 									return false;
 								}
 							});
-							
+
 							break;
 						case 'T':
 							this.setClientStateCustom('clSelectTech', _('Select Technology'), [], {
@@ -1966,7 +1979,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 									this.setClientStateCustom('client_selectShipToPay', _('Select a ship or discard a card to pay cost'), {
 										selectionList: payment_token,
 										buthandler: (node_id) => {
-								
+
 											var icons = this.getRulesFor(node_id, 'i');
 											var icons_count = 0;
 
@@ -2008,7 +2021,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 										onCard: (id) => {
 											if (!this.checkActivePlayer()) return true;
 											if (!this.checkActiveSlot(id)) return true;
-											
+
 											this.gamedatas.gamestate.args.buthandler(id);
 											return true;
 										}
@@ -2024,7 +2037,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							var card_name = this.getTokenName(this.gamedatas.gamestate.args.card);
 							if (lookup !== 'q') message = _('${you} must choose a planet to keep for ${card_name} (last one)');
 							else message = _('${you} must choose a planet to keep for ${card_name}');
-							this.setClientStateCustom('clSelectPlanetToKeep', message , {
+							this.setClientStateCustom('clSelectPlanetToKeep', message, {
 								card_name: card_name
 							}, {
 								onUpdateActionButtons: (args) => {
@@ -2100,7 +2113,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							return true; // submit
 						case 'x':// skip
 							return this.commitOperationAndAction(command);
-						
+
 						case 'i': // gain inf
 						case 'R': // reaseach icon
 						case 'd': // draw
@@ -2116,14 +2129,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					return false;
 				},
-				getRoleCard: function(type) {
+				getRoleCard: function (type) {
 					var nodes = dojo.query(".board .card_role_" + type);
 					if (nodes.length > 0) return nodes[0].id;
 					else
 						return "x_" + type + "_bottom";//x_research_bottom
 				},
 
-				getRulesFor: function(card_id, field) {
+				getRulesFor: function (card_id, field) {
 					if (field == undefined) field = 'r';
 					var key = card_id;
 					while (key) {
@@ -2144,7 +2157,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					return rule;
 				},
 
-				getCostRule: function(card_id) {
+				getCostRule: function (card_id) {
 					var rcost = this.getRulesFor(card_id, 'b');
 					var mcost = this.getRulesFor(card_id, 'bm');
 					var rcoststr = this.strRepeat('R', rcost);
@@ -2159,7 +2172,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 				},
 
-				updateMyCountersAll: function() {
+				updateMyCountersAll: function () {
 					// console.log("updating counters");
 					// var type = ".card:not(.card_bottom)";
 					// this.updateLocalCounter('supply_survey', type);
@@ -2174,7 +2187,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					//	this.updateLocalCounter('tableau_fighter_' + playerInfo.color, '.fighter:not(.counter)');
 					//}
 				},
-				updatePermCounters: function(color, perm_boost_num) {
+				updatePermCounters: function (color, perm_boost_num) {
 					var role_icons = this.gamedatas.materials.role_icons;
 					for (var i in role_icons) {
 						var x = role_icons[i];
@@ -2183,7 +2196,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						if ($(counter)) $(counter).innerHTML = perm_boost_count;
 					}
 				},
-				updateLocalCounter: function(location, childtype) {
+				updateLocalCounter: function (location, childtype) {
 					var query = dojo.query("#" + location + ' ' + childtype);
 					var counter = location + '_counter';
 					//console.log("** LOCAL counter " + counter + " -> " + query.length);
@@ -2191,7 +2204,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					else
 						console.error("Cannot find counter " + counter);
 				},
-				expandTech: function(state, query, loc) {
+				expandTech: function (state, query, loc) {
 					console.log("expand tech " + state);
 					if (typeof query == 'undefined') {
 						query = ".supply_tech .tech";
@@ -2207,7 +2220,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						} else {
 							dojo.place('selection_area_controls', 'selection_area', 'first');
 						}
-				
+
 						var queryres = dojo.query(query);
 						queryres.forEach((elt, i) => {
 							// console.log("expand tech " + elt.id);
@@ -2231,13 +2244,13 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							dojo.query(query).forEach((elt, i) => {
 								// console.log("expand tech " + elt.id);
 								var info = this.getTokenDisplayInfo(elt.id);
-		
+
 								if (info.side != 2) return;// ??? should not happen
 								var rloc = loc;
 								var relation = undefined;
-		
+
 								var flip = info.flip;
-						
+
 								var flipNode = $(flip);
 								if (flipNode && flipNode.parentNode.id.startsWith(loc)) {
 									rloc = flip;
@@ -2251,11 +2264,10 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							);
 						}, queryres.length * 2 + 100);
 
-						setTimeout(() => this.updateFilters(), queryres.length * 2 +600);
+						setTimeout(() => this.updateFilters(), queryres.length * 2 + 600);
 					} else {
 						dojo.place('selection_area_controls', 'selection_area', 'first');
-		
-						
+
 						if (loc == 'discard_display') {
 							queryFold = ".discard_display  .card";
 							queryUnexpand = ".discard_display";
@@ -2265,6 +2277,9 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						} else if (loc == 'planets_display') {
 							queryFold = ".planets_display  .card";
 							queryUnexpand = ".planets_display";
+						} else if (loc == 'tech_display') {
+							queryFold = ".tech_display .card";
+							queryUnexpand = ".inspect_display";
 						} else {
 							queryFold = ".common_space  .tech,.selection_area .tech,.inspect_display  .card";
 							queryUnexpand = ".inspect_display";
@@ -2272,7 +2287,6 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 						dojo.query(queryFold).forEach(
 							(elt) => {
-								// console.log("expand tech " + elt.id);
 								this.removeTooltip(elt.id);
 								this.placeToken(elt.id);
 							});
@@ -2280,7 +2294,45 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						dojo.query(queryUnexpand).removeClass('expanded');
 					}
 				},
-				playAction: function(card_id, rules) {
+				hideScenario: function () {
+					dojo.query("#selection_area .scenario").forEach((elt) => dojo.addClass(elt, "hidden"));
+				},
+				expandScenario: function () {
+					console.log("expand scenario");
+					query = "#scenarios .scenario";
+					loc = "selection_area"
+
+					dojo.addClass('selection_area_controls', 'hidden')
+					dojo.addClass(loc, 'expanded');
+					var queryres = dojo.query(query);
+					queryres.forEach((elt, i) => {
+						var info = this.getTokenDisplayInfo(elt.id);
+						if (info.side == 2) {
+							return;
+						}
+						var rloc = loc;
+
+						this.slideToObjectRelative(elt.id, rloc, 500, i * 2, (node) => {
+							this.updateTooltip(node.id);
+						});
+
+						this.connectClass(elt.id, 'onclick', 'onCard');
+						dojo.addClass(elt.id, 'clickable');
+					});
+				},
+				onCard_scenarioSelection: function (card_id) {
+					const beginsWith = card_id.substring(0, 8);
+					if (beginsWith !== "scenario") {
+						return false;
+					}
+
+					this.clientStateArgs.card = card_id;
+					this.clientStateArgs.action = 'selectScenario';
+					this.clientStateArgs.unprocessed_choices = '';
+					this.actionPromptAndCommit();
+					return true;
+				},
+				playAction: function (card_id, rules) {
 					if (rules === undefined)
 						rules = this.getRulesFor(card_id, 'a');
 					this.clientStateArgs.card = card_id;
@@ -2304,7 +2356,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				 * Most of the time, these methods: _ check the action is possible at this game state. _ make a call to the game server
 				 * 
 				 */
-				onCard: function(event) {
+				onCard: function (event) {
 					var id = event.currentTarget.id;
 					dojo.stopEvent(event);
 					console.log("on slot " + id);
@@ -2354,7 +2406,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					switch (this.getStateName()) {
 						case 'playerTurnDiscard':
 						case 'playerTurnPreDiscard':
-						
+
 							checkActive = false;
 							break;
 						case 'client_selectResourceToTrade':
@@ -2414,14 +2466,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								dojo.addClass(card_id, 'selected');
 								dojo.removeClass(card_id, 'active_slot');
 							}
-							var divpick = dojo.query(".hand .card.selected").map(function(node) {
+							var divpick = dojo.query(".hand .card.selected").map(function (node) {
 								return node.id;
 							}).join(" ");
 							this.clientStateArgs.boost = divpick;
 							return;
 						case 'client_selectTechCard':
 							if (this.commitOperation('R', card_id)) {
-								dojo.removeClass(card_id,'active_slot');
+								dojo.removeClass(card_id, 'active_slot');
 								this.placeTokenLocal(card_id, 'setaside_' + this.player_color, 1);
 								this.expandTech(false);
 								var crule = this.getCostRule(card_id);
@@ -2738,11 +2790,13 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 
 							return;
 					}
+
+					console.log('no actions found');
 					this.showMoveUnauthorized();
 				},
 
 
-				onExecuteRole: function(event) {
+				onExecuteRole: function (event) {
 					var id = this.onClickSanity(event, false);
 					if (id == null) return;
 					var total = getIntPart(id, 1);
@@ -2788,7 +2842,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							var args = this.gamedatas.gamestate.args;
 							var total = args.perm_boost_count + args.hand_boost_count;
 							var message = _('SURVEY: Draw ${look} planets - keep ${keep} (unused boost ${remaining_boost})');
-						
+
 							if (leader) total++;
 							var look = total - 1;
 							var keep = 1;
@@ -2812,8 +2866,8 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 								remaining_boost: args.possible_boost
 							});
 
-							this.setClientStateAction('client_confirm',text);
-	
+							this.setClientStateAction('client_confirm', text);
+
 							break;
 						case 'P':
 							var args = this.gamedatas.gamestate.args;
@@ -2859,14 +2913,14 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 							break;
 					}
 				},
-				onDeck: function(event) {
+				onDeck: function (event) {
 					var id = event.currentTarget.id;
 					dojo.stopEvent(event);
 					console.log("on slot " + id);
 					if (id == null || this.isSpectator) return;
 					this.revealLocation(id);
 				},
-				onDiscard: function(event) {
+				onDiscard: function (event) {
 					var id = event.currentTarget.id;
 					dojo.stopEvent(event);
 					console.log("on slot " + id);
@@ -2874,7 +2928,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					this.revealLocation(id);
 				},
 
-				revealLocation: function(id, activate) {
+				revealLocation: function (id, activate) {
 					var location = 'discard_display';
 					if (id == 'discard_planets' || id == 'planets_display' || id == 'supply_planets') {
 						location = 'planets_display';
@@ -2891,7 +2945,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						return;
 					}
 					var self = this;
-					func = function(result) {
+					func = function (result) {
 						console.log(result);
 						if (result.data && result.data.contents) {
 							if (result.data.length > 0) {
@@ -2913,7 +2967,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					this.ajaxAction(action, args, func);
 
 				},
-				onResource: function(event) {
+				onResource: function (event) {
 					var id = this.onClickSanity(event, true);
 					if (id == null) return;
 					var resource = id;
@@ -2942,7 +2996,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					this.showMoveUnauthorized();
 				},
 
-				onFighter: function(event) {
+				onFighter: function (event) {
 					var id = this.onClickSanity(event, false);
 					if (id == null) return;
 
@@ -2994,13 +3048,13 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 					}
 					this.showMoveUnauthorized();
 				},
-				onSlider: function(event) {
+				onSlider: function (event) {
 					var id = event.currentTarget.id;
 					dojo.stopEvent(event);
 					var sliderId = id;
 					this.onSliderChange(sliderId);
 				},
-				onSliderChange: function(sliderId) {
+				onSliderChange: function (sliderId) {
 					var slider_value = $(sliderId).value;
 					var output = document.getElementById(sliderId + "_value");
 					output.innerHTML = slider_value;
@@ -3018,12 +3072,12 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 						}
 					this.updateFilters();
 				},
-				onCheckbox: function(event) {
+				onCheckbox: function (event) {
 					//var id = event.currentTarget.id;
 					dojo.stopEvent(event);
 					this.updateFilters();
 				},
-				updateFilters: function() {
+				updateFilters: function () {
 					var hide_opacity = 0.3;
 					dojo.query(".filter_control_area .card").forEach((node) => {
 						dojo.style(node, "opacity", 1);
@@ -3077,7 +3131,7 @@ define(["dojo", "dojo/_base/declare", "ebg/core/gamegui", "ebg/counter",
 				 * Note: game notification names correspond to "notifyAllPlayers" and "notifyPlayer" calls in your eminentdomain.game.php file.
 				 * 
 				 */
-				setupNotifications: function() {
+				setupNotifications: function () {
 					console.log('notifications subscriptions setup enminent');
 					this.inherited(arguments);
 				},

--- a/eminentdomain_eminentdomain.tpl
+++ b/eminentdomain_eminentdomain.tpl
@@ -252,7 +252,6 @@
 							class="counter supply_counter slot_tooltip">0</div>
 					</div>
 					<div id="supply_fleet" class="supply_fleet supply_hidden"></div>
-
 				</div>
 
 				<div id="tech_display" class="tech_display inspect_display filter_control_area">
@@ -298,6 +297,11 @@
 					</div>
 
 				</div>
+
+				<div id="scenarios"
+					class="supply_hidden">
+				</div>
+
 				<div id="limbo" class="supply_hidden"></div>
 
 				<div id="dev_null"></div>

--- a/gameoptions.inc.php
+++ b/gameoptions.inc.php
@@ -29,76 +29,126 @@ $game_options = array(
         100 => array(
                 'name' => totranslate('Learning Game (No Research)'),
                 'values' => array(
-                        
-                        1 => array( 'name' => totranslate('Off')), 
-                        2 => array( 'name' => totranslate('On'), 'tmdisplay' => totranslate('Learning Game') ),
-                        
+
+                        1 => array('name' => totranslate('Off')),
+                        2 => array('name' => totranslate('On'), 'tmdisplay' => totranslate('Learning Game')),
+
                 ),
                 'displaycondition' => array(
                         // Note: do not display this option unless these conditions are met
-                        array( 'type' => 'otheroption',
+                        array(
+                                'type' => 'otheroption',
                                 'id' => 201, // ELO OFF hardcoded framework option
                                 'value' => 1, // 1 if OFF
 
                         )
                 ),
                 'notdisplayedmessage' => totranslate('Learning variant available only with ELO off')
-                ),
-    
+        ),
+
         101 => array(
                 'name' => totranslate('Extended 3-Player Game'),
                 'values' => array(
-                        1 => array( 'name' => totranslate('Off'), 
-                                'nobeginner' => false  ),
-                        2 => array( 'name' => totranslate('On'), 'tmdisplay' => totranslate('Extended'),
-                                'nobeginner' => true  ),
-                        
+                        1 => array(
+                                'name' => totranslate('Off'),
+                                'nobeginner' => false
+                        ),
+                        2 => array(
+                                'name' => totranslate('On'), 'tmdisplay' => totranslate('Extended'),
+                                'nobeginner' => true
+                        ),
+
                 ),
         ),
         102 => array(
                 'name' => totranslate('Scenarios'),
                 'values' => array(
-                        1 => array( 'name' => totranslate('Off'),
-                                'nobeginner' => false  ),
-                        2 => array( 'name' => totranslate('On'), 'tmdisplay' => totranslate('Scenarios'),
-                                'nobeginner' => true  ),
-                        
+                        1 => array(
+                                'name' => totranslate('Off'),
+                                'nobeginner' => false
+                        ),
+                        2 => array(
+                                'name' => totranslate('On'), 'tmdisplay' => totranslate('Scenarios'),
+                                'nobeginner' => true
+                        ),
+
                 ),
                 'displaycondition' => array(
                         // Note: do not display this option unless these conditions are met
-                        array( 'type' => 'otheroptionisnot',
+                        array(
+                                'type' => 'otheroptionisnot',
                                 'id' => 100, // learning variant
                                 'value' => 2, // 1 if OFF,2 is ON
-                                
+
                         )
                 ),
                 'notdisplayedmessage' => totranslate('Scenarios variant is not available if Learning variant is chosen')
         ),
+        105 => array(
+                'alpha' => true,
+                'name' => totranslate('Scenario Selection'),
+                'values' => array(
+                        1 => array(
+                                'name' => totranslate('Off'),
+                                'nobeginner' => false
+                        ),
+                        2 => array(
+                                'name' => totranslate('On'), 'tmdisplay' => totranslate('Scenario Selection'),
+                                'nobeginner' => true
+                        ),
+
+                ),
+                'displaycondition' => array(
+                        array(
+                                'type' => 'otheroptionisnot',
+                                'id' => 100, // learning variant
+                                'value' => 2, // 1 if OFF,2 is ON
+
+                        ),
+                        array(
+                                'type' => 'otheroption',
+                                'id' => 102, // scenario variant
+                                'value' => 2, // 1 if OFF,2 is ON
+
+                        )
+                ),
+                'default' => 1,
+                'notdisplayedmessage' => totranslate('This variant is not available without Scenarios')
+        ),
         103 => array(
                 'name' => totranslate('Extra Turn after Game End Triggered'),
                 'values' => array(
-                        1 => array( 'name' => totranslate('Off'),
-                                'nobeginner' => false  ),
-                        2 => array( 'name' => totranslate('On'), 'tmdisplay' => totranslate('Extra Turn'),
-                                'nobeginner' => false  ),
-                        
+                        1 => array(
+                                'name' => totranslate('Off'),
+                                'nobeginner' => false
+                        ),
+                        2 => array(
+                                'name' => totranslate('On'), 'tmdisplay' => totranslate('Extra Turn'),
+                                'nobeginner' => false
+                        ),
+
                 ),
                 'default' => 2
         ),
         104 => array(
                 'name' => totranslate('Escalation Expansion'),
                 'values' => array(
-                        1 => array( 'name' => totranslate('Off'),
-                                'nobeginner' => false  ),
-                        2 => array( 'name' => totranslate('On'), 'tmdisplay' => totranslate('Escalation'),
-                                'nobeginner' => true  ),
-                        
+                        1 => array(
+                                'name' => totranslate('Off'),
+                                'nobeginner' => false
+                        ),
+                        2 => array(
+                                'name' => totranslate('On'), 'tmdisplay' => totranslate('Escalation'),
+                                'nobeginner' => true
+                        ),
+
                 ),
                 'displaycondition' => array(
-                        array( 'type' => 'otheroptionisnot',
+                        array(
+                                'type' => 'otheroptionisnot',
                                 'id' => 100, // learning variant
                                 'value' => 2, // 1 if OFF,2 is ON
-                                
+
                         )
                 ),
                 'default' => 1,
@@ -108,10 +158,10 @@ $game_options = array(
 );
 
 if (!defined('PREF_AUTO_DISSENT')) { // guard since this included multiple times
-    define("PREF_AUTO_DISSENT", 150);
-    define("PREFVALUE_AUTO_DISSENT_ON", 1);
-    define("PREFVALUE_AUTO_DISSENT_OFF", 0);
-    define("PREFVALUE_AUTO_DISSENT_TIMER", 2);
+        define("PREF_AUTO_DISSENT", 150);
+        define("PREFVALUE_AUTO_DISSENT_ON", 1);
+        define("PREFVALUE_AUTO_DISSENT_OFF", 0);
+        define("PREFVALUE_AUTO_DISSENT_TIMER", 2);
 }
 
 
@@ -120,9 +170,9 @@ $game_preferences = array(
                 'name' => totranslate('Auto Dissent'),
                 //'needReload' => true, // after user changes this preference game interface would auto-reload
                 'values' => array(
-                        PREFVALUE_AUTO_DISSENT_OFF => array( 'name' => totranslate( 'No Auto Dissent' ), 'cssPref' => 'dissent_manual' ),
-                        PREFVALUE_AUTO_DISSENT_ON => array( 'name' => totranslate( 'Auto Dissent' ), 'cssPref' => 'dissent_auto' ),
-                        PREFVALUE_AUTO_DISSENT_TIMER => array( 'name' => totranslate( 'Auto Dissent with Timer' ), 'cssPref' => 'dissent_timer' ),
+                        PREFVALUE_AUTO_DISSENT_OFF => array('name' => totranslate('No Auto Dissent'), 'cssPref' => 'dissent_manual'),
+                        PREFVALUE_AUTO_DISSENT_ON => array('name' => totranslate('Auto Dissent'), 'cssPref' => 'dissent_auto'),
+                        PREFVALUE_AUTO_DISSENT_TIMER => array('name' => totranslate('Auto Dissent with Timer'), 'cssPref' => 'dissent_timer'),
                 ),
                 'default' => PREFVALUE_AUTO_DISSENT_ON,
                 'server_sync' => true

--- a/material.inc.php
+++ b/material.inc.php
@@ -76,6 +76,13 @@ $this->token_types = array(
   'tooltip_action' => clienttranslate("Cannot inspect"),
   'loc'=>1,'content'=>0,'counter'=>1 ,
 ],
+'starting_worlds' => [
+  'type' => 'supply_planets',
+  'name' => clienttranslate("Starting Worlds Deck"),
+  'tooltip' => clienttranslate("Starting Worlds Supply Deck"),
+  'tooltip_action' => clienttranslate("Cannot inspect"),
+  'loc'=>1,'content'=>0,'counter'=>1 ,
+],
 'fighter_F' => [
   'type' => 'fighter',
   'name' => clienttranslate("Fighter"),
@@ -201,6 +208,11 @@ $this->token_types = array(
 'supply_research' => [
   'type' => 'supply',
   'name' => clienttranslate("Research Roles Deck"),
+  'loc'=>1,'content'=>1,'counter'=>1 ,
+],
+'supply_scenarios' => [
+  'type' => 'supply',
+  'name' => clienttranslate("Scenarios Deck"),
   'loc'=>1,'content'=>1,'counter'=>1 ,
 ],
 'supply_tech_A' => [

--- a/modules/php/EminentDomain/Setup.php
+++ b/modules/php/EminentDomain/Setup.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace EminentDomain;
+
+class Setup
+{
+    static function BuildDecks(int $playerCount, bool $extended_variant): array
+    {
+        switch ($playerCount) {
+            case 2:
+                $setupnums = [16, 14, 16, 12, 16];
+                break;
+            case 3:
+                if ($extended_variant)
+                    $setupnums = [18, 15, 18, 14, 18];
+                else
+                    $setupnums = [20, 16, 20, 16, 20];
+                break;
+            case 4:
+                $setupnums = [20, 16, 20, 16, 20];
+                break;
+            case 5:
+                $setupnums = [24, 20, 24, 20, 24];
+                break;
+            default:
+                $setupnums = [16, 14, 16, 12, 16];
+                break;
+        }
+
+        return $setupnums;
+    }
+
+    static function GetMaxVP(int $playerCount): int
+    {
+        return $playerCount === 5 ? 32 : 24;
+    }
+}

--- a/modules/php/EminentDomain/index.php
+++ b/modules/php/EminentDomain/index.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once('Setup.php');

--- a/states.inc.php
+++ b/states.inc.php
@@ -50,116 +50,153 @@
 //    !! It is not a good idea to modify this file when a game is running !!
 
 if (!defined('STATE_END_GAME')) { // guard since this included multiple times
-    define("STATE_PLAYER_TURN_ACTION", 2);
-    define("STATE_GAME_TURN_NEXT_PLAYER_FOLLOW", 3);
-    define("STATE_GAME_TURN_NEXT_PLAYER", 4);
-    define("STATE_GAME_TURN_UPKEEP", 5);
-    define("STATE_PLAYER_TURN_ROLE", 6);
-    define("STATE_PLAYER_TURN_DISCARD", 7);
-    define("STATE_PLAYER_TURN_PRE_DISCARD", 12);
-    define("STATE_PLAYER_TURN_SURVEY", 8);
-    define("STATE_PLAYER_TURN_ROLE_EXTRA", 26); // // extra data collection for leader role
-    define("STATE_PLAYER_GAME_END", 9);
-    define("STATE_PLAYER_TURN_FOLLOW", 10);
-    define("STATE_PLAYER_TURN_SURVEY_FOLLOW", 11);
-    define("STATE_PLAYER_TURN_FOLLOW_EXTRA", 21); // extra data collection for follow role
-    define("STATE_PLAYER_TURN_ACTION_EXTRA", 22); // extra data collection for action 
-    define("STATE_END_GAME", 99);
+        define("STATE_PLAYER_TURN_ACTION", 2);
+        define("STATE_GAME_TURN_NEXT_PLAYER_FOLLOW", 3);
+        define("STATE_GAME_TURN_NEXT_PLAYER", 4);
+        define("STATE_GAME_TURN_UPKEEP", 5);
+        define("STATE_PLAYER_TURN_ROLE", 6);
+        define("STATE_PLAYER_TURN_DISCARD", 7);
+        define("STATE_PLAYER_TURN_PRE_DISCARD", 12);
+        define("STATE_PLAYER_TURN_SURVEY", 8);
+        define("STATE_PLAYER_TURN_ROLE_EXTRA", 26); // // extra data collection for leader role
+        define("STATE_PLAYER_GAME_END", 9);
+        define("STATE_PLAYER_TURN_FOLLOW", 10);
+        define("STATE_PLAYER_TURN_SURVEY_FOLLOW", 11);
+        define("STATE_PLAYER_TURN_FOLLOW_EXTRA", 21); // extra data collection for follow role
+        define("STATE_PLAYER_TURN_ACTION_EXTRA", 22); // extra data collection for action 
+        define("STATE_SCENARIO_SELECTION", 23);
+        define("STATE_SCENARIO_SELECTION_NEXT_PLAYER", 24);
+        define("STATE_GAME_PLAYER_SETUP", 25);
+        define("STATE_END_GAME", 99);
 }
 
- 
+
 $machinestates = array(
 
-    // The initial state. Please do not modify.
-    1 => array(
-        "name" => "gameSetup",
-        "description" => "",
-        "type" => "manager",
-        "action" => "stGameSetup",
-        "transitions" => array( "" => STATE_PLAYER_TURN_ACTION )
-    ),
-    
-    // Note: ID=2 => your first state
+        // The initial state. Please do not modify.
+        1 => array(
+                "name" => "gameSetup",
+                "description" => "",
+                "type" => "manager",
+                "action" => "stGameSetup",
+                "transitions" => array("" => STATE_SCENARIO_SELECTION)
+        ),
+        STATE_SCENARIO_SELECTION => array(
+                "name" => "scenarioSelection",
+                "action" => "st_selectScenario",
+                "type" => "activeplayer",
+                "description" => clienttranslate('${actplayer} must choose a scenario'),
+                "descriptionmyturn" => clienttranslate('${you} must choose to a scenario'),
+                "possibleactions" => array("selectScenario"),
+                "transitions" => array(
+                        "" => STATE_SCENARIO_SELECTION_NEXT_PLAYER
+                )
+        ),
+        STATE_SCENARIO_SELECTION_NEXT_PLAYER => array(
+                "name" => "nextPlayer",
+                "description" => "",
+                "type" => "game",
+                "action" => "st_scenarioNextPlayer",
+                "transitions" => array(
+                        "nextPlayer" => STATE_SCENARIO_SELECTION,
+                        "last" => STATE_GAME_PLAYER_SETUP
+                )
+        ),
+        STATE_GAME_PLAYER_SETUP => array(
+                "name" => "gamePlayerSetup",
+                "description" => '',
+                "type" => "game",
+                "action" => "st_gamePlayerSetup",
+                "updateGameProgression" => false,
+                "transitions" => array("" => STATE_PLAYER_TURN_ACTION)
+        ),
 
-    STATE_PLAYER_TURN_ACTION => array(
-    		"name" => "playerTurnAction",
-    		"description" => clienttranslate('${actplayer} may play an action'),
-    		"descriptionmyturn" => clienttranslate('${you} may play an action'),
-    		"type" => "activeplayer",
-            "args"=>"arg_playerTurnAction",
-            "possibleactions" => array( "playAction", "skipAction",  "playActivatePermanent", "playExtra" ),
-            "transitions" => array( 
-                    "next" => STATE_PLAYER_TURN_ROLE, 
-                    "loopback"=> STATE_PLAYER_TURN_ACTION,
-                    "last"=>STATE_GAME_TURN_UPKEEP)
-    ),
-    STATE_PLAYER_TURN_ROLE => array(
-            "name" => "playerTurnRole",
-            "description" => clienttranslate('${actplayer} must play a role'),
-            "descriptionmyturn" => clienttranslate('${you} must play a role'),
-            "type" => "activeplayer",
-            "args"=>"arg_playerTurnRole",
-            "possibleactions" => array( "playRole", "playActivatePermanent" ),
-            "transitions" => array( 
-                    "discard" => STATE_PLAYER_TURN_PRE_DISCARD, 
-                    "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
-                    "loopback"=>STATE_PLAYER_TURN_ROLE,
-                    "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA)
-    ),
+        // Note: ID=2 => your first state
+
+        STATE_PLAYER_TURN_ACTION => array(
+                "name" => "playerTurnAction",
+                "description" => clienttranslate('${actplayer} may play an action'),
+                "descriptionmyturn" => clienttranslate('${you} may play an action'),
+                "type" => "activeplayer",
+                "args" => "arg_playerTurnAction",
+                "possibleactions" => array("playAction", "skipAction",  "playActivatePermanent", "playExtra"),
+                "transitions" => array(
+                        "next" => STATE_PLAYER_TURN_ROLE,
+                        "loopback" => STATE_PLAYER_TURN_ACTION,
+                        "last" => STATE_GAME_TURN_UPKEEP
+                )
+        ),
+        STATE_PLAYER_TURN_ROLE => array(
+                "name" => "playerTurnRole",
+                "description" => clienttranslate('${actplayer} must play a role'),
+                "descriptionmyturn" => clienttranslate('${you} must play a role'),
+                "type" => "activeplayer",
+                "args" => "arg_playerTurnRole",
+                "possibleactions" => array("playRole", "playActivatePermanent"),
+                "transitions" => array(
+                        "discard" => STATE_PLAYER_TURN_PRE_DISCARD,
+                        "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
+                        "loopback" => STATE_PLAYER_TURN_ROLE,
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
+                )
+        ),
         STATE_PLAYER_TURN_PRE_DISCARD => array(
                 "name" => "playerTurnPreDiscard",
                 "description" => clienttranslate('${actplayer} may discard cards'),
                 "descriptionmyturn" => clienttranslate('${you} may discard some cards from your hand, if you do your turn will end'),
                 "type" => "activeplayer",
-                "args"=>"arg_playerTurnRole",
-                "possibleactions" => array( "playDiscard" , "playActivatePermanent", "playWait"  ),
+                "args" => "arg_playerTurnRole",
+                "possibleactions" => array("playDiscard", "playActivatePermanent", "playWait"),
                 "transitions" => array(
                         "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
-                        "loopback"=>STATE_PLAYER_TURN_PRE_DISCARD,
-                        "discard"=>STATE_PLAYER_TURN_PRE_DISCARD,
-                        "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA)
+                        "loopback" => STATE_PLAYER_TURN_PRE_DISCARD,
+                        "discard" => STATE_PLAYER_TURN_PRE_DISCARD,
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
+                )
         ),
         STATE_PLAYER_TURN_DISCARD => array(
                 "name" => "playerTurnDiscard",
                 "description" => clienttranslate('${actplayer} may discard cards'),
                 "descriptionmyturn" => clienttranslate('${you} may discard some cards from your hand'),
                 "type" => "activeplayer",
-                "args"=>"arg_playerTurnRole",
-                "possibleactions" => array( "playDiscard" , "playActivatePermanent" ),
-                "transitions" => array( 
+                "args" => "arg_playerTurnRole",
+                "possibleactions" => array("playDiscard", "playActivatePermanent"),
+                "transitions" => array(
                         "next" => STATE_GAME_TURN_UPKEEP,
-                        "loopback"=>STATE_PLAYER_TURN_DISCARD,
-                        "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA)
+                        "loopback" => STATE_PLAYER_TURN_DISCARD,
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
+                )
         ),
         STATE_PLAYER_TURN_SURVEY => array( // not used anymore, keep for backward compat
                 "name" => "playerTurnSurvey",
                 "description" => clienttranslate('${actplayer} must choose a planet to keep'),
                 "descriptionmyturn" => clienttranslate('${you} must choose a planet to keep'),
                 "type" => "activeplayer",
-                "args"=>"arg_playerTurnRole",
-                "possibleactions" => array( "playPick" ),
-                "transitions" => array (
+                "args" => "arg_playerTurnRole",
+                "possibleactions" => array("playPick"),
+                "transitions" => array(
                         "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
                         "role" => STATE_PLAYER_TURN_ROLE,
                         "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
                 )
         ),
-        
+
         STATE_PLAYER_TURN_ROLE_EXTRA => array(
                 "name" => "playerTurnRoleExtra",
                 "description" => clienttranslate('${actplayer} ${state_prompt}'),
                 "descriptionmyturn" => clienttranslate('${you} ${state_prompt}'),
                 "type" => "activeplayer",
-                "args"=>"arg_playerTurnRoleExtra",
-                "possibleactions" => array( "playPick","playActivatePermanent","playExtra","playDiscard" ),
+                "args" => "arg_playerTurnRoleExtra",
+                "possibleactions" => array("playPick", "playActivatePermanent", "playExtra", "playDiscard"),
                 "transitions" => array(
                         "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
                         "survey" => STATE_PLAYER_TURN_SURVEY,
-                        "loopback"=>STATE_PLAYER_TURN_ROLE_EXTRA,
-                        "discard" => STATE_PLAYER_TURN_PRE_DISCARD, 
-                        "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA)
+                        "loopback" => STATE_PLAYER_TURN_ROLE_EXTRA,
+                        "discard" => STATE_PLAYER_TURN_PRE_DISCARD,
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
+                )
         ),
-        
+
         STATE_GAME_TURN_UPKEEP => array(
                 "name" => "gameTurnUpkeep",
                 "description" => clienttranslate('Cleanup...'),
@@ -171,30 +208,33 @@ $machinestates = array(
                         "action" => STATE_PLAYER_TURN_ACTION,
                         "role" => STATE_PLAYER_TURN_ROLE,
                         "next" =>  STATE_GAME_TURN_NEXT_PLAYER,
-                        "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA
-                        ), 
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
+                ),
         ),
-        
+
         STATE_PLAYER_TURN_SURVEY_FOLLOW => array( // not used anymore, keep for backward compat
                 "name" => "playerTurnSurveyFollow",
                 "description" => clienttranslate('${actplayer} must choose a planet to keep'),
                 "descriptionmyturn" => clienttranslate('${you} must choose a planet to keep'),
                 "type" => "activeplayer",
-                "args"=>"arg_playerTurnRole",
-                "possibleactions" => array( "playPick" ),
-                "transitions" => array( "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
-                        "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA)
+                "args" => "arg_playerTurnRole",
+                "possibleactions" => array("playPick"),
+                "transitions" => array(
+                        "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
+                )
         ),
         STATE_GAME_TURN_NEXT_PLAYER => array(
-            "name" => "gameTurnNextPlayer",
-            "description" => clienttranslate('Replenish...'),
-            "type" => "game",
-            "action" => "st_gameTurnNextPlayer",
-            "updateGameProgression" => true,
-            "transitions" => array(
+                "name" => "gameTurnNextPlayer",
+                "description" => clienttranslate('Replenish...'),
+                "type" => "game",
+                "action" => "st_gameTurnNextPlayer",
+                "updateGameProgression" => true,
+                "transitions" => array(
                         "next" => STATE_PLAYER_TURN_ACTION,
                         "loopback" =>  STATE_GAME_TURN_NEXT_PLAYER,
-                    "last" => STATE_END_GAME), // to test change to STATE_PLAYER_GAME_END
+                        "last" => STATE_END_GAME
+                ), // to test change to STATE_PLAYER_GAME_END
         ),
         STATE_GAME_TURN_NEXT_PLAYER_FOLLOW => array(
                 "name" => "gameTurnNextPlayerFollow",
@@ -205,46 +245,45 @@ $machinestates = array(
                 "transitions" => array(
                         "next" => STATE_PLAYER_TURN_FOLLOW,
                         "loopback" =>  STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
-                        "last"=>STATE_GAME_TURN_UPKEEP,
-                        
-                        ),
+                        "last" => STATE_GAME_TURN_UPKEEP,
+
+                ),
         ),
-        STATE_PLAYER_TURN_FOLLOW => array (
+        STATE_PLAYER_TURN_FOLLOW => array(
                 "name" => "playerTurnFollow",
                 "type" => "multipleactiveplayer",
                 "description" => clienttranslate('Other players must choose to Follow ${otherplayer}\'s "${role_name}" role or Dissent'),
                 "descriptionmyturn" => clienttranslate('${you} must choose to Follow ${otherplayer}\'s "${role_name}" role or Dissent'),
-                "possibleactions" => array ("playFollow","playDissent","playWait" ),
-                "transitions" => array (
+                "possibleactions" => array("playFollow", "playDissent", "playWait"),
+                "transitions" => array(
                         "next" => STATE_GAME_TURN_NEXT_PLAYER_FOLLOW,
                         "loopback" => STATE_PLAYER_TURN_FOLLOW,
-                        "extra"=>STATE_PLAYER_TURN_ROLE_EXTRA
+                        "extra" => STATE_PLAYER_TURN_ROLE_EXTRA
                 ),
-                "args" => "arg_playerTurnFollow" 
+                "args" => "arg_playerTurnFollow"
         ),
-       
+
         STATE_PLAYER_GAME_END => array(
                 "name" => "playerTurnGameEnd",
                 "description" => clienttranslate('${actplayer} must end the game (development state, remove before production)'),
                 "descriptionmyturn" => clienttranslate('${you} must end the game (development state, remove before production)'),
                 "type" => "activeplayer",
-                "args"=>"arg_playerTurnRole",
-                "possibleactions" => array( "skipAction" ),
-                "transitions" => array( "next" => STATE_END_GAME,
-                        "last" => STATE_END_GAME )
+                "args" => "arg_playerTurnRole",
+                "possibleactions" => array("skipAction"),
+                "transitions" => array(
+                        "next" => STATE_END_GAME,
+                        "last" => STATE_END_GAME
+                )
         ),
-   
-    // Final state.
-    // Please do not modify.
-   STATE_END_GAME => array(
-        "name" => "gameEnd",
-        "description" => clienttranslate("End of game"),
-        "type" => "manager",
-        "action" => "stGameEnd",
-        "args" => "argGameEnd"
-    )
+
+        // Final state.
+        // Please do not modify.
+        STATE_END_GAME => array(
+                "name" => "gameEnd",
+                "description" => clienttranslate("End of game"),
+                "type" => "manager",
+                "action" => "stGameEnd",
+                "args" => "argGameEnd"
+        )
 
 );
-
-
-


### PR DESCRIPTION
Add a new game setup option for selecting scenarios rather than using random assignment

At the start of the game, in turn order, players select a scenario card. Scenario cards will be removed if they conflict with a chosen scenario (e.g. Fertile Ground and Abundance both use the same Technology card). Once everyone has chosen, setup continues as normal.